### PR TITLE
Migrate logs to tracing

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,7 +24,6 @@ rust_binary(
         "@crate_index//:async-lock",
         "@crate_index//:axum",
         "@crate_index//:clap",
-        "@crate_index//:env_logger",
         "@crate_index//:futures",
         "@crate_index//:hyper",
         "@crate_index//:parking_lot",
@@ -36,6 +35,8 @@ rust_binary(
         "@crate_index//:tokio-rustls",
         "@crate_index//:tonic",
         "@crate_index//:tower",
+        "@crate_index//:tracing",
+        "@crate_index//:tracing-subscriber",
     ],
 )
 

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5c9608af6e959d25bdae4ff438bca27d04472bf9c473c0b131727c9e96e96c50",
+  "checksum": "23af5237f25c8c8d8b18e23ebbe5438fcbe890c9983d2b5a8d183f2de498fa5d",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -29,7 +29,7 @@
         "deps": {
           "common": [
             {
-              "id": "gimli 0.28.0",
+              "id": "gimli 0.28.1",
               "target": "gimli"
             }
           ],
@@ -115,7 +115,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "zerocopy 0.7.26",
+              "id": "zerocopy 0.7.28",
               "target": "zerocopy"
             }
           ],
@@ -722,7 +722,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -887,7 +887,7 @@
               "target": "hyper"
             },
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "ring"
             },
             {
@@ -1637,7 +1637,7 @@
               "target": "regex"
             },
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "ring"
             },
             {
@@ -3483,13 +3483,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "clap 4.4.8": {
+    "clap 4.4.10": {
       "name": "clap",
-      "version": "4.4.8",
+      "version": "4.4.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/4.4.8/download",
-          "sha256": "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+          "url": "https://crates.io/api/v1/crates/clap/4.4.10/download",
+          "sha256": "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
         }
       },
       "targets": [
@@ -3524,7 +3524,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.4.8",
+              "id": "clap_builder 4.4.9",
               "target": "clap_builder"
             }
           ],
@@ -3540,17 +3540,17 @@
           ],
           "selects": {}
         },
-        "version": "4.4.8"
+        "version": "4.4.10"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_builder 4.4.8": {
+    "clap_builder 4.4.9": {
       "name": "clap_builder",
-      "version": "4.4.8",
+      "version": "4.4.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_builder/4.4.8/download",
-          "sha256": "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+          "url": "https://crates.io/api/v1/crates/clap_builder/4.4.9/download",
+          "sha256": "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
         }
       },
       "targets": [
@@ -3602,7 +3602,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.4.8"
+        "version": "4.4.9"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3644,7 +3644,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -3783,13 +3783,13 @@
       },
       "license": "CC0-1.0 OR MIT-0 OR Apache-2.0"
     },
-    "core-foundation 0.9.3": {
+    "core-foundation 0.9.4": {
       "name": "core-foundation",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/core-foundation/0.9.3/download",
-          "sha256": "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+          "url": "https://crates.io/api/v1/crates/core-foundation/0.9.4/download",
+          "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
         }
       },
       "targets": [
@@ -3808,10 +3808,17 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "link"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "core-foundation-sys 0.8.4",
+              "id": "core-foundation-sys 0.8.6",
               "target": "core_foundation_sys"
             },
             {
@@ -3821,18 +3828,18 @@
           ],
           "selects": {}
         },
-        "edition": "2015",
-        "version": "0.9.3"
+        "edition": "2018",
+        "version": "0.9.4"
       },
-      "license": "MIT / Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
-    "core-foundation-sys 0.8.4": {
+    "core-foundation-sys 0.8.6": {
       "name": "core-foundation-sys",
-      "version": "0.8.4",
+      "version": "0.8.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/core-foundation-sys/0.8.4/download",
-          "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+          "url": "https://crates.io/api/v1/crates/core-foundation-sys/0.8.6/download",
+          "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
         }
       },
       "targets": [
@@ -3851,10 +3858,17 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "0.8.4"
+        "crate_features": {
+          "common": [
+            "default",
+            "link"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.6"
       },
-      "license": "MIT / Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "cpufeatures 0.2.11": {
       "name": "cpufeatures",
@@ -4149,49 +4163,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ctor 0.2.5": {
-      "name": "ctor",
-      "version": "0.2.5",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ctor/0.2.5/download",
-          "sha256": "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "ctor",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ctor",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "quote 1.0.33",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.39",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.2.5"
-      },
-      "license": "Apache-2.0 OR MIT"
-    },
     "der 0.6.1": {
       "name": "der",
       "version": "0.6.1",
@@ -4244,13 +4215,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "deranged 0.3.9": {
+    "deranged 0.3.10": {
       "name": "deranged",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/deranged/0.3.9/download",
-          "sha256": "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+          "url": "https://crates.io/api/v1/crates/deranged/0.3.10/download",
+          "sha256": "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
         }
       },
       "targets": [
@@ -4287,7 +4258,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.9"
+        "version": "0.3.10"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4707,71 +4678,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "env_logger 0.10.1": {
-      "name": "env_logger",
-      "version": "0.10.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/env_logger/0.10.1/download",
-          "sha256": "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "env_logger",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "env_logger",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "auto-color",
-            "color",
-            "default",
-            "humantime",
-            "regex"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "humantime 2.1.0",
-              "target": "humantime"
-            },
-            {
-              "id": "is-terminal 0.4.9",
-              "target": "is_terminal"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "regex 1.10.2",
-              "target": "regex"
-            },
-            {
-              "id": "termcolor 1.4.0",
-              "target": "termcolor"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.10.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "equivalent 1.0.1": {
       "name": "equivalent",
       "version": "1.0.1",
@@ -4802,13 +4708,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "errno 0.3.7": {
+    "errno 0.3.8": {
       "name": "errno",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/errno/0.3.7/download",
-          "sha256": "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+          "url": "https://crates.io/api/v1/crates/errno/0.3.8/download",
+          "sha256": "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
         }
       },
       "targets": [
@@ -4856,14 +4762,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.3.7"
+        "version": "0.3.8"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4979,7 +4885,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -5333,13 +5239,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "formatx 0.2.1": {
+    "formatx 0.2.2": {
       "name": "formatx",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/formatx/0.2.1/download",
-          "sha256": "201b6da898350ca377d39368db6776154c63e4ad0c5480dadae52f51938ca528"
+          "url": "https://crates.io/api/v1/crates/formatx/0.2.2/download",
+          "sha256": "db0f0c49aba98a3b2578315766960bd242885ff672fd62610c5557cd6c6efe03"
         }
       },
       "targets": [
@@ -5359,7 +5265,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5686,7 +5592,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -6049,13 +5955,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gimli 0.28.0": {
+    "gimli 0.28.1": {
       "name": "gimli",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gimli/0.28.0/download",
-          "sha256": "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+          "url": "https://crates.io/api/v1/crates/gimli/0.28.1/download",
+          "sha256": "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
         }
       },
       "targets": [
@@ -6075,7 +5981,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.28.0"
+        "version": "0.28.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6288,13 +6194,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "hashbrown 0.14.2": {
+    "hashbrown 0.14.3": {
       "name": "hashbrown",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hashbrown/0.14.2/download",
-          "sha256": "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+          "url": "https://crates.io/api/v1/crates/hashbrown/0.14.3/download",
+          "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
         }
       },
       "targets": [
@@ -6337,7 +6243,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.14.2"
+        "version": "0.14.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6714,36 +6620,6 @@
         "version": "1.0.3"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "humantime 2.1.0": {
-      "name": "humantime",
-      "version": "2.1.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/humantime/2.1.0/download",
-          "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "humantime",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "humantime",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "2.1.0"
-      },
-      "license": "MIT/Apache-2.0"
     },
     "hyper 0.14.27": {
       "name": "hyper",
@@ -7155,7 +7031,7 @@
               "target": "equivalent"
             },
             {
-              "id": "hashbrown 0.14.2",
+              "id": "hashbrown 0.14.3",
               "target": "hashbrown"
             }
           ],
@@ -7165,59 +7041,6 @@
         "version": "2.1.0"
       },
       "license": "Apache-2.0 OR MIT"
-    },
-    "is-terminal 0.4.9": {
-      "name": "is-terminal",
-      "version": "0.4.9",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/is-terminal/0.4.9/download",
-          "sha256": "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "is_terminal",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "is_terminal",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
-              {
-                "id": "rustix 0.38.25",
-                "target": "rustix"
-              }
-            ],
-            "cfg(target_os = \"hermit\")": [
-              {
-                "id": "hermit-abi 0.3.3",
-                "target": "hermit_abi"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "windows-sys 0.48.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.4.9"
-      },
-      "license": "MIT"
     },
     "itertools 0.10.5": {
       "name": "itertools",
@@ -7450,13 +7273,13 @@
       },
       "license": "MIT"
     },
-    "linux-raw-sys 0.4.11": {
+    "linux-raw-sys 0.4.12": {
       "name": "linux-raw-sys",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/linux-raw-sys/0.4.11/download",
-          "sha256": "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+          "url": "https://crates.io/api/v1/crates/linux-raw-sys/0.4.12/download",
+          "sha256": "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
         }
       },
       "targets": [
@@ -7486,7 +7309,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.11"
+        "version": "0.4.12"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
@@ -7723,6 +7546,45 @@
         "version": "1.0.2"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "matchers 0.1.0": {
+      "name": "matchers",
+      "version": "0.1.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/matchers/0.1.0/download",
+          "sha256": "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "matchers",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "matchers",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "regex-automata 0.1.10",
+              "target": "regex_automata"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.0"
+      },
+      "license": "MIT"
     },
     "matchit 0.7.3": {
       "name": "matchit",
@@ -8122,12 +7984,8 @@
               "target": "axum"
             },
             {
-              "id": "clap 4.4.8",
+              "id": "clap 4.4.10",
               "target": "clap"
-            },
-            {
-              "id": "env_logger 0.10.1",
-              "target": "env_logger"
             },
             {
               "id": "futures 0.3.29",
@@ -8172,6 +8030,14 @@
             {
               "id": "tower 0.4.13",
               "target": "tower"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.18",
+              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
@@ -8250,7 +8116,7 @@
               "target": "futures"
             },
             {
-              "id": "hashbrown 0.14.2",
+              "id": "hashbrown 0.14.3",
               "target": "hashbrown"
             },
             {
@@ -8284,6 +8150,10 @@
             {
               "id": "tonic 0.9.2",
               "target": "tonic"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             },
             {
               "id": "uuid 1.6.1",
@@ -8372,6 +8242,10 @@
             {
               "id": "tonic 0.9.2",
               "target": "tonic"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             },
             {
               "id": "uuid 1.6.1",
@@ -8529,6 +8403,10 @@
               "target": "tonic"
             },
             {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
               "id": "uuid 1.6.1",
               "target": "uuid"
             }
@@ -8663,6 +8541,10 @@
             {
               "id": "tokio-util 0.7.10",
               "target": "tokio_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             }
           ],
           "selects": {}
@@ -8733,7 +8615,7 @@
               "target": "filetime"
             },
             {
-              "id": "formatx 0.2.1",
+              "id": "formatx 0.2.2",
               "target": "formatx"
             },
             {
@@ -8785,6 +8667,10 @@
               "target": "tonic"
             },
             {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
               "id": "uuid 1.6.1",
               "target": "uuid"
             }
@@ -8793,10 +8679,6 @@
         },
         "deps_dev": {
           "common": [
-            {
-              "id": "env_logger 0.10.1",
-              "target": "env_logger"
-            },
             {
               "id": "hyper 0.14.27",
               "target": "hyper"
@@ -8826,15 +8708,6 @@
             {
               "id": "async-trait 0.1.74",
               "target": "async_trait"
-            }
-          ],
-          "selects": {}
-        },
-        "proc_macro_deps_dev": {
-          "common": [
-            {
-              "id": "ctor 0.2.5",
-              "target": "ctor"
             }
           ],
           "selects": {}
@@ -9731,7 +9604,7 @@
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -9909,7 +9782,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -10195,7 +10068,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -10265,7 +10138,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -10348,7 +10221,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -10377,13 +10250,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.69": {
+    "proc-macro2 1.0.70": {
       "name": "proc-macro2",
-      "version": "1.0.69",
+      "version": "1.0.70",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.69/download",
-          "sha256": "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.70/download",
+          "sha256": "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
         }
       },
       "targets": [
@@ -10421,7 +10294,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "build_script_build"
             },
             {
@@ -10432,7 +10305,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.69"
+        "version": "1.0.70"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10549,7 +10422,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -10760,7 +10633,7 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -10915,7 +10788,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             }
           ],
@@ -11283,6 +11156,53 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "regex-automata 0.1.10": {
+      "name": "regex-automata",
+      "version": "0.1.10",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/regex-automata/0.1.10/download",
+          "sha256": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "regex_automata",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "regex_automata",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "regex-syntax",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "regex-syntax 0.6.29",
+              "target": "regex_syntax"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.1.10"
+      },
+      "license": "Unlicense/MIT"
+    },
     "regex-automata 0.4.3": {
       "name": "regex-automata",
       "version": "0.4.3",
@@ -11354,6 +11274,50 @@
         },
         "edition": "2021",
         "version": "0.4.3"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "regex-syntax 0.6.29": {
+      "name": "regex-syntax",
+      "version": "0.6.29",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.29/download",
+          "sha256": "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "regex_syntax",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "regex_syntax",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "unicode",
+            "unicode-age",
+            "unicode-bool",
+            "unicode-case",
+            "unicode-gencat",
+            "unicode-perl",
+            "unicode-script",
+            "unicode-segment"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.6.29"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11485,13 +11449,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "ring 0.17.5": {
+    "ring 0.17.6": {
       "name": "ring",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ring/0.17.5/download",
-          "sha256": "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+          "url": "https://crates.io/api/v1/crates/ring/0.17.6/download",
+          "sha256": "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
         }
       },
       "targets": [
@@ -11534,7 +11498,7 @@
               "target": "getrandom"
             },
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "build_script_build"
             },
             {
@@ -11543,6 +11507,12 @@
             }
           ],
           "selects": {
+            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
+              {
+                "id": "libc 0.2.150",
+                "target": "libc"
+              }
+            ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
               {
                 "id": "windows-sys 0.48.0",
@@ -11554,17 +11524,11 @@
                 "id": "spin 0.9.8",
                 "target": "spin"
               }
-            ],
-            "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
-              {
-                "id": "libc 0.2.150",
-                "target": "libc"
-              }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.17.5"
+        "version": "0.17.6"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11579,7 +11543,7 @@
           ],
           "selects": {}
         },
-        "links": "ring_core_0_17_5"
+        "links": "ring_core_0_17_6"
       },
       "license": null
     },
@@ -11698,13 +11662,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "rustix 0.38.25": {
+    "rustix 0.38.26": {
       "name": "rustix",
-      "version": "0.38.25",
+      "version": "0.38.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustix/0.38.25/download",
-          "sha256": "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+          "url": "https://crates.io/api/v1/crates/rustix/0.38.26/download",
+          "sha256": "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
         }
       },
       "targets": [
@@ -11741,27 +11705,22 @@
           "selects": {
             "aarch64-apple-darwin": [
               "default",
-              "termios",
               "use-libc-auxv"
             ],
             "aarch64-unknown-linux-gnu": [
               "default",
-              "termios",
               "use-libc-auxv"
             ],
             "arm-unknown-linux-gnueabi": [
               "default",
-              "termios",
               "use-libc-auxv"
             ],
             "armv7-unknown-linux-gnueabi": [
               "default",
-              "termios",
               "use-libc-auxv"
             ],
             "x86_64-unknown-linux-gnu": [
               "default",
-              "termios",
               "use-libc-auxv"
             ]
           }
@@ -11773,26 +11732,26 @@
               "target": "bitflags"
             },
             {
-              "id": "rustix 0.38.25",
+              "id": "rustix 0.38.26",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "linux-raw-sys 0.4.11",
+                "id": "linux-raw-sys 0.4.12",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
               {
-                "id": "linux-raw-sys 0.4.11",
+                "id": "linux-raw-sys 0.4.12",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "errno 0.3.7",
+                "id": "errno 0.3.8",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -11803,19 +11762,19 @@
             ],
             "cfg(windows)": [
               {
-                "id": "errno 0.3.7",
+                "id": "errno 0.3.8",
                 "target": "errno",
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.38.25"
+        "version": "0.38.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11874,7 +11833,7 @@
               "target": "log"
             },
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "ring"
             },
             {
@@ -11902,7 +11861,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "ring"
             }
           ],
@@ -12044,7 +12003,7 @@
         "deps": {
           "common": [
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "ring"
             },
             {
@@ -12246,7 +12205,7 @@
         "deps": {
           "common": [
             {
-              "id": "ring 0.17.5",
+              "id": "ring 0.17.6",
               "target": "ring"
             },
             {
@@ -12373,11 +12332,11 @@
               "target": "bitflags"
             },
             {
-              "id": "core-foundation 0.9.3",
+              "id": "core-foundation 0.9.4",
               "target": "core_foundation"
             },
             {
-              "id": "core-foundation-sys 0.8.4",
+              "id": "core-foundation-sys 0.8.6",
               "target": "core_foundation_sys"
             },
             {
@@ -12430,7 +12389,7 @@
         "deps": {
           "common": [
             {
-              "id": "core-foundation-sys 0.8.4",
+              "id": "core-foundation-sys 0.8.6",
               "target": "core_foundation_sys"
             },
             {
@@ -12610,7 +12569,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -13617,7 +13576,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -13688,7 +13647,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -13776,7 +13735,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "rustix 0.38.25",
+                "id": "rustix 0.38.26",
                 "target": "rustix"
               }
             ],
@@ -13798,47 +13757,6 @@
         "version": "3.8.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "termcolor 1.4.0": {
-      "name": "termcolor",
-      "version": "1.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/termcolor/1.4.0/download",
-          "sha256": "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "termcolor",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "termcolor",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(windows)": [
-              {
-                "id": "winapi-util 0.1.6",
-                "target": "winapi_util"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "1.4.0"
-      },
-      "license": "Unlicense OR MIT"
     },
     "thiserror 1.0.50": {
       "name": "thiserror",
@@ -13930,7 +13848,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -14029,7 +13947,7 @@
         "deps": {
           "common": [
             {
-              "id": "deranged 0.3.9",
+              "id": "deranged 0.3.10",
               "target": "deranged"
             },
             {
@@ -14396,7 +14314,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -14771,7 +14689,7 @@
               "target": "prettyplease"
             },
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -15058,7 +14976,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -15258,9 +15176,13 @@
             "alloc",
             "ansi",
             "default",
+            "env-filter",
             "fmt",
             "json",
+            "matchers",
             "nu-ansi-term",
+            "once_cell",
+            "regex",
             "registry",
             "serde",
             "serde_json",
@@ -15268,6 +15190,7 @@
             "smallvec",
             "std",
             "thread_local",
+            "tracing",
             "tracing-log",
             "tracing-serde"
           ],
@@ -15276,8 +15199,20 @@
         "deps": {
           "common": [
             {
+              "id": "matchers 0.1.0",
+              "target": "matchers"
+            },
+            {
               "id": "nu-ansi-term 0.46.0",
               "target": "nu_ansi_term"
+            },
+            {
+              "id": "once_cell 1.18.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "regex 1.10.2",
+              "target": "regex"
             },
             {
               "id": "serde 1.0.193",
@@ -15298,6 +15233,10 @@
             {
               "id": "thread_local 1.1.7",
               "target": "thread_local"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             },
             {
               "id": "tracing-core 0.1.32",
@@ -16043,7 +15982,7 @@
               "target": "either"
             },
             {
-              "id": "rustix 0.38.25",
+              "id": "rustix 0.38.26",
               "target": "rustix"
             }
           ],
@@ -16111,12 +16050,6 @@
             "processenv",
             "processthreadsapi",
             "psapi",
-            "std",
-            "sysinfoapi",
-            "winbase",
-            "wincon",
-            "winerror",
-            "winnt",
             "ws2ipdef",
             "ws2tcpip"
           ],
@@ -16207,47 +16140,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "winapi-util 0.1.6": {
-      "name": "winapi-util",
-      "version": "0.1.6",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi-util/0.1.6/download",
-          "sha256": "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "winapi_util",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "winapi_util",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(windows)": [
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.1.6"
-      },
-      "license": "Unlicense/MIT"
-    },
     "winapi-x86_64-pc-windows-gnu 0.4.0": {
       "name": "winapi-x86_64-pc-windows-gnu",
       "version": "0.4.0",
@@ -16331,8 +16223,6 @@
             "Win32",
             "Win32_Foundation",
             "Win32_Globalization",
-            "Win32_NetworkManagement",
-            "Win32_NetworkManagement_IpHelper",
             "Win32_Networking",
             "Win32_Networking_WinSock",
             "Win32_Security",
@@ -16345,8 +16235,6 @@
             "Win32_System",
             "Win32_System_Com",
             "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
             "Win32_System_IO",
             "Win32_System_Memory",
             "Win32_System_Pipes",
@@ -16370,6 +16258,61 @@
         },
         "edition": "2018",
         "version": "0.48.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-sys 0.52.0": {
+      "name": "windows-sys",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-sys/0.52.0/download",
+          "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "Win32",
+            "Win32_Foundation",
+            "Win32_NetworkManagement",
+            "Win32_NetworkManagement_IpHelper",
+            "Win32_Networking",
+            "Win32_Networking_WinSock",
+            "Win32_System",
+            "Win32_System_Diagnostics",
+            "Win32_System_Diagnostics_Debug",
+            "Win32_System_Threading",
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "windows-targets 0.52.0",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16450,6 +16393,83 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows-targets 0.52.0": {
+      "name": "windows-targets",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-targets/0.52.0/download",
+          "sha256": "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_targets",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_targets",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-gnullvm": [
+              {
+                "id": "windows_aarch64_gnullvm 0.52.0",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_aarch64_msvc 0.52.0",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_i686_gnu 0.52.0",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_i686_msvc 0.52.0",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_gnu 0.52.0",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_msvc 0.52.0",
+                "target": "windows_x86_64_msvc"
+              }
+            ],
+            "x86_64-pc-windows-gnullvm": [
+              {
+                "id": "windows_x86_64_gnullvm 0.52.0",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.52.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_aarch64_gnullvm 0.48.5": {
       "name": "windows_aarch64_gnullvm",
       "version": "0.48.5",
@@ -16495,6 +16515,59 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_aarch64_gnullvm 0.52.0": {
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.52.0/download",
+          "sha256": "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_gnullvm 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16556,6 +16629,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_aarch64_msvc 0.52.0": {
+      "name": "windows_aarch64_msvc",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.52.0/download",
+          "sha256": "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_msvc 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_i686_gnu 0.48.5": {
       "name": "windows_i686_gnu",
       "version": "0.48.5",
@@ -16601,6 +16727,59 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_gnu 0.52.0": {
+      "name": "windows_i686_gnu",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.52.0/download",
+          "sha256": "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnu 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16662,6 +16841,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_i686_msvc 0.52.0": {
+      "name": "windows_i686_msvc",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.52.0/download",
+          "sha256": "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_msvc 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_x86_64_gnu 0.48.5": {
       "name": "windows_x86_64_gnu",
       "version": "0.48.5",
@@ -16707,6 +16939,59 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_gnu 0.52.0": {
+      "name": "windows_x86_64_gnu",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.52.0/download",
+          "sha256": "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnu 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16768,6 +17053,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_x86_64_gnullvm 0.52.0": {
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.52.0/download",
+          "sha256": "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnullvm 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_x86_64_msvc 0.48.5": {
       "name": "windows_x86_64_msvc",
       "version": "0.48.5",
@@ -16813,6 +17151,59 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_msvc 0.52.0": {
+      "name": "windows_x86_64_msvc",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.52.0/download",
+          "sha256": "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_msvc 0.52.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16888,13 +17279,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "zerocopy 0.7.26": {
+    "zerocopy 0.7.28": {
       "name": "zerocopy",
-      "version": "0.7.26",
+      "version": "0.7.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zerocopy/0.7.26/download",
-          "sha256": "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+          "url": "https://crates.io/api/v1/crates/zerocopy/0.7.28/download",
+          "sha256": "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
         }
       },
       "targets": [
@@ -16925,23 +17316,23 @@
           "selects": {
             "cfg(any())": [
               {
-                "id": "zerocopy-derive 0.7.26",
+                "id": "zerocopy-derive 0.7.28",
                 "target": "zerocopy_derive"
               }
             ]
           }
         },
-        "version": "0.7.26"
+        "version": "0.7.28"
       },
       "license": "BSD-2-Clause OR Apache-2.0 OR MIT"
     },
-    "zerocopy-derive 0.7.26": {
+    "zerocopy-derive 0.7.28": {
       "name": "zerocopy-derive",
-      "version": "0.7.26",
+      "version": "0.7.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zerocopy-derive/0.7.26/download",
-          "sha256": "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+          "url": "https://crates.io/api/v1/crates/zerocopy-derive/0.7.28/download",
+          "sha256": "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
         }
       },
       "targets": [
@@ -16963,7 +17354,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.69",
+              "id": "proc-macro2 1.0.70",
               "target": "proc_macro2"
             },
             {
@@ -16978,7 +17369,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.7.26"
+        "version": "0.7.28"
       },
       "license": "BSD-2-Clause OR Apache-2.0 OR MIT"
     },
@@ -17048,6 +17439,11 @@
       "armv7-unknown-linux-gnueabi"
     ],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [],
+    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-unknown-linux-gnueabi"
+    ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
       "arm-unknown-linux-gnueabi",
@@ -17100,12 +17496,6 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu"
     ],
-    "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-unknown-linux-gnueabi",
-      "x86_64-unknown-linux-gnu"
-    ],
     "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"macos\", target_os = \"ios\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
@@ -17138,13 +17528,6 @@
       "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
-      "aarch64-apple-darwin",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-unknown-linux-gnueabi",
-      "x86_64-unknown-linux-gnu"
-    ],
-    "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "arm-unknown-linux-gnueabi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -717,9 +717,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -775,9 +775,9 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -839,16 +839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
-dependencies = [
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -902,7 +892,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -950,19 +940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,12 +947,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1033,7 +1010,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1075,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "formatx"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201b6da898350ca377d39368db6776154c63e4ad0c5480dadae52f51938ca528"
+checksum = "db0f0c49aba98a3b2578315766960bd242885ff672fd62610c5557cd6c6efe03"
 
 [[package]]
 name = "futures"
@@ -1191,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "group"
@@ -1242,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1283,7 +1260,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1319,12 +1296,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1406,18 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1460,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -1503,6 +1463,15 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -1559,7 +1528,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1581,7 +1550,6 @@ dependencies = [
  "async-lock",
  "axum",
  "clap",
- "env_logger",
  "error",
  "futures",
  "hyper",
@@ -1601,6 +1569,8 @@ dependencies = [
  "tokio-rustls",
  "tonic",
  "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1619,7 +1589,7 @@ dependencies = [
  "blake3",
  "error",
  "futures",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "lru",
  "native-link-config",
  "native-link-store",
@@ -1633,6 +1603,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tracing",
  "uuid",
 ]
 
@@ -1660,6 +1631,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tracing",
  "uuid",
 ]
 
@@ -1701,6 +1673,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tracing",
  "uuid",
 ]
 
@@ -1732,6 +1705,7 @@ dependencies = [
  "sha2",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1741,8 +1715,6 @@ dependencies = [
  "async-lock",
  "async-trait",
  "bytes",
- "ctor",
- "env_logger",
  "error",
  "filetime",
  "formatx",
@@ -1768,6 +1740,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tracing",
  "uuid",
 ]
 
@@ -1891,7 +1864,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2055,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2226,8 +2199,17 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2238,8 +2220,14 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2266,16 +2254,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2304,15 +2292,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2376,7 +2364,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2599,7 +2587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2674,16 +2662,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.4.1",
  "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
-dependencies = [
- "winapi-util",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2775,7 +2754,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2969,12 +2948,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3135,15 +3118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,7 +3129,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -3164,13 +3147,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -3180,10 +3178,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3192,10 +3202,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3204,16 +3226,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "xmlparser"
@@ -3229,18 +3269,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ native-link-worker = { path = "native-link-worker" }
 async-lock = "2.7.0"
 axum = "0.6.18"
 clap = { version = "4.3.11", features = ["derive"] }
-env_logger = "0.10.0"
 futures = "0.3.28"
 hyper = { version = "0.14.27" }
 parking_lot = "0.12.1"
@@ -43,3 +42,5 @@ tokio = { version = "1.29.1", features = ["rt-multi-thread", "signal"] }
 tokio-rustls = "0.24.1"
 tonic = { version = "0.9.2", features = ["gzip"] }
 tower = "0.4.13"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/native-link-scheduler/BUILD.bazel
+++ b/native-link-scheduler/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
         "@crate_index//:tokio",
         "@crate_index//:tokio-stream",
         "@crate_index//:tonic",
+        "@crate_index//:tracing",
         "@crate_index//:uuid",
     ],
 )

--- a/native-link-scheduler/Cargo.toml
+++ b/native-link-scheduler/Cargo.toml
@@ -26,6 +26,7 @@ scopeguard = "1.2.0"
 tokio = { version = "1.29.1", features = ["sync", "rt", "parking_lot"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
+tracing = "0.1.40"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/native-link-scheduler/src/simple_scheduler.rs
+++ b/native-link-scheduler/src/simple_scheduler.rs
@@ -29,7 +29,6 @@ use native_link_config::schedulers::WorkerAllocationStrategy;
 use native_link_util::action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ExecutionMetadata,
 };
-use native_link_util::common::log;
 use native_link_util::metrics_utils::{
     AsyncCounterWrapper, Collector, CollectorState, CounterWithTime, FuncCounterWrapper, MetricsComponent, Registry,
 };
@@ -38,6 +37,7 @@ use parking_lot::{Mutex, MutexGuard};
 use tokio::sync::{watch, Notify};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
+use tracing::{error, warn};
 
 use crate::action_scheduler::ActionScheduler;
 use crate::platform_property_manager::PlatformPropertyManager;
@@ -119,7 +119,7 @@ impl Workers {
             .send_initial_connection_result()
             .err_tip(|| "Failed to send initial connection result to worker");
         if let Err(e) = &res {
-            log::error!(
+            error!(
                 "Worker connection appears to have been closed while adding to pool : {:?}",
                 e
             );
@@ -355,7 +355,7 @@ impl SimpleSchedulerImpl {
                     // Don't remove this task, instead we keep them around for a bit just in case
                     // the client disconnected and will reconnect and ask for same job to be executed
                     // again.
-                    log::warn!(
+                    warn!(
                         "Action {} has no more listeners during evict_worker()",
                         action_info.digest().hash_str()
                     );
@@ -363,7 +363,7 @@ impl SimpleSchedulerImpl {
             }
             None => {
                 self.metrics.retry_action_but_action_missing.inc();
-                log::error!("Worker stated it was running an action, but it was not in the active_actions : Worker: {:?}, ActionInfo: {:?}", worker_id, action_info);
+                error!("Worker stated it was running an action, but it was not in the active_actions : Worker: {:?}, ActionInfo: {:?}", worker_id, action_info);
             }
         }
     }
@@ -397,7 +397,7 @@ impl SimpleSchedulerImpl {
         let action_infos: Vec<Arc<ActionInfo>> = self.queued_actions.keys().rev().cloned().collect();
         for action_info in action_infos {
             let Some(awaited_action) = self.queued_actions.get(action_info.as_ref()) else {
-                log::error!(
+                error!(
                     "queued_actions out of sync with itself for action {}",
                     action_info.digest().hash_str()
                 );
@@ -416,7 +416,7 @@ impl SimpleSchedulerImpl {
             if notify_worker_result.is_err() {
                 // Remove worker, as it is no longer receiving messages and let it try to find another worker.
                 let err = make_err!(Code::Internal, "Worker command failed, removing worker {}", worker_id);
-                log::warn!("{:?}", err);
+                warn!("{:?}", err);
                 self.immediate_evict_worker(&worker_id, err);
                 return;
             }
@@ -433,7 +433,7 @@ impl SimpleSchedulerImpl {
                 // Don't remove this task, instead we keep them around for a bit just in case
                 // the client disconnected and will reconnect and ask for same job to be executed
                 // again.
-                log::warn!(
+                warn!(
                     "Action {} has no more listeners",
                     awaited_action.action_info.digest().hash_str()
                 );
@@ -458,7 +458,7 @@ impl SimpleSchedulerImpl {
         self.metrics.update_action_with_internal_error.inc();
         let Some((action_info, mut running_action)) = self.active_actions.remove_entry(action_info_hash_key) else {
             self.metrics.update_action_with_internal_error_no_action.inc();
-            log::error!("Could not find action info in active actions : {action_info_hash_key:?}");
+            error!("Could not find action info in active actions : {action_info_hash_key:?}");
             return;
         };
 
@@ -471,11 +471,11 @@ impl SimpleSchedulerImpl {
 
         if running_action.worker_id == *worker_id {
             // Don't set the error on an action that's running somewhere else.
-            log::warn!("Internal error for worker {}: {}", worker_id, err);
+            warn!("Internal error for worker {}: {}", worker_id, err);
             running_action.action.last_error = Some(err.clone());
         } else {
             self.metrics.update_action_with_internal_error_from_wrong_worker.inc();
-            log::error!(
+            error!(
                 "Got a result from a worker that should not be running the action, Removing worker. Expected worker {} got worker {}",
                     running_action.worker_id, worker_id
             );
@@ -512,7 +512,7 @@ impl SimpleSchedulerImpl {
                 Code::Internal,
                 "Worker '{worker_id}' set the action_stage of running action {action_info_hash_key:?} to {action_stage:?}. Removing worker.",
             );
-            log::error!("{:?}", err);
+            error!("{:?}", err);
             self.immediate_evict_worker(worker_id, err.clone());
             return Err(err);
         }
@@ -529,7 +529,7 @@ impl SimpleSchedulerImpl {
                 "Got a result from a worker that should not be running the action, Removing worker. Expected worker {} got worker {worker_id}",
                 running_action.worker_id,
             );
-            log::error!("{:?}", err);
+            error!("{:?}", err);
             // First put it back in our active_actions or we will drop the task.
             self.active_actions.insert(action_info, running_action);
             self.immediate_evict_worker(worker_id, err.clone());
@@ -546,7 +546,7 @@ impl SimpleSchedulerImpl {
         if !running_action.action.current_state.stage.is_finished() {
             if send_result.is_err() {
                 self.metrics.update_action_no_more_listeners.inc();
-                log::warn!(
+                warn!(
                     "Action {} has no more listeners during update_action()",
                     action_info.digest().hash_str()
                 );
@@ -819,7 +819,7 @@ impl WorkerScheduler for SimpleScheduler {
                 .collect();
             for worker_id in &worker_ids_to_remove {
                 let err = make_err!(Code::Internal, "Worker {worker_id} timed out, removing from pool");
-                log::warn!("{:?}", err);
+                warn!("{:?}", err);
                 inner.immediate_evict_worker(worker_id, err);
             }
 

--- a/native-link-service/BUILD.bazel
+++ b/native-link-service/BUILD.bazel
@@ -34,6 +34,7 @@ rust_library(
         "@crate_index//:tokio",
         "@crate_index//:tokio-stream",
         "@crate_index//:tonic",
+        "@crate_index//:tracing",
         "@crate_index//:uuid",
     ],
 )

--- a/native-link-service/Cargo.toml
+++ b/native-link-service/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.8.5"
 tokio = { version = "1.29.1", features = ["sync", "rt"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
+tracing = "0.1.40"
 uuid = { version = "1.4.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/native-link-service/src/ac_server.rs
+++ b/native-link-service/src/ac_server.rs
@@ -24,12 +24,13 @@ use native_link_config::cas_server::{AcStoreConfig, InstanceName};
 use native_link_store::ac_utils::{get_and_decode_digest, ESTIMATED_DIGEST_SIZE};
 use native_link_store::grpc_store::GrpcStore;
 use native_link_store::store_manager::StoreManager;
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::store_trait::Store;
 use prost::Message;
 use proto::build::bazel::remote::execution::v2::action_cache_server::{ActionCache, ActionCacheServer as Server};
 use proto::build::bazel::remote::execution::v2::{ActionResult, GetActionResultRequest, UpdateActionResultRequest};
 use tonic::{Request, Response, Status};
+use tracing::{error, info};
 
 pub struct AcServer {
     stores: HashMap<String, Arc<dyn Store>>,
@@ -133,7 +134,7 @@ impl ActionCache for AcServer {
         grpc_request: Request<GetActionResultRequest>,
     ) -> Result<Response<ActionResult>, Status> {
         let now = Instant::now();
-        log::info!("\x1b[0;31mget_action_result Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mget_action_result Req\x1b[0m: {:?}", grpc_request.get_ref());
         let hash = grpc_request
             .get_ref()
             .action_digest
@@ -142,9 +143,9 @@ impl ActionCache for AcServer {
         let resp = self.inner_get_action_result(grpc_request).await;
         let d = now.elapsed().as_secs_f32();
         if resp.is_err() && resp.as_ref().err().unwrap().code != Code::NotFound {
-            log::error!("\x1b[0;31mget_action_result Resp\x1b[0m: {} {:?} {:?}", d, hash, resp);
+            error!("\x1b[0;31mget_action_result Resp\x1b[0m: {} {:?} {:?}", d, hash, resp);
         } else {
-            log::info!("\x1b[0;31mget_action_result Resp\x1b[0m: {} {:?} {:?}", d, hash, resp);
+            info!("\x1b[0;31mget_action_result Resp\x1b[0m: {} {:?} {:?}", d, hash, resp);
         }
         return resp.map_err(|e| e.into());
     }
@@ -154,7 +155,7 @@ impl ActionCache for AcServer {
         grpc_request: Request<UpdateActionResultRequest>,
     ) -> Result<Response<ActionResult>, Status> {
         let now = Instant::now();
-        log::info!(
+        info!(
             "\x1b[0;31mupdate_action_result Req\x1b[0m: {:?}",
             grpc_request.get_ref()
         );

--- a/native-link-service/src/bytestream_server.rs
+++ b/native-link-service/src/bytestream_server.rs
@@ -28,7 +28,7 @@ use native_link_config::cas_server::ByteStreamConfig;
 use native_link_store::grpc_store::GrpcStore;
 use native_link_store::store_manager::StoreManager;
 use native_link_util::buf_channel::{make_buf_channel_pair, DropCloserReadHalf, DropCloserWriteHalf};
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::resource_info::ResourceInfo;
 use native_link_util::store_trait::{Store, UploadSizeInfo};
 use native_link_util::write_request_stream_wrapper::WriteRequestStreamWrapper;
@@ -40,6 +40,7 @@ use proto::google::bytestream::{
 use tokio::task::AbortHandle;
 use tokio::time::sleep;
 use tonic::{Request, Response, Status, Streaming};
+use tracing::{enabled, error, info, Level};
 
 /// If this value changes update the documentation in the config definition.
 const DEFAULT_PERSIST_STREAM_ON_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(60);
@@ -87,7 +88,7 @@ impl<'a> Drop for ActiveStreamGuard<'a> {
         let mut active_uploads = self.bytestream_server.active_uploads.lock();
         let uuid = stream_state.uuid.clone();
         let Some(active_uploads_slot) = active_uploads.get_mut(&uuid) else {
-            log::error!(
+            error!(
                 "Failed to find active upload for UUID: {}. This should never happen.",
                 uuid
             );
@@ -100,7 +101,7 @@ impl<'a> Drop for ActiveStreamGuard<'a> {
                 (*sleep_fn)().await;
                 if let Some(active_uploads) = weak_active_uploads.upgrade() {
                     let mut active_uploads = active_uploads.lock();
-                    log::debug!("Removing idle stream {uuid}");
+                    info!("Removing idle stream {uuid}");
                     active_uploads.remove(&uuid);
                 }
             })
@@ -191,7 +192,7 @@ impl ByteStreamServer {
         let mut active_uploads = self.active_uploads.lock();
         if let Some(maybe_idle_stream) = active_uploads.get_mut(&uuid) {
             if let Some(idle_stream) = maybe_idle_stream.1.take() {
-                log::info!("Joining existing stream {uuid}");
+                info!("Joining existing stream {uuid}");
                 return Ok(idle_stream.into_active_stream(maybe_idle_stream.0.clone(), self));
             }
             return Err(make_input_err!("Cannot upload same UUID simultaneously"));
@@ -286,7 +287,7 @@ impl ByteStreamServer {
                                     return Some((Err(err.into()), None));
                                 }
                                 let response = ReadResponse { data: bytes };
-                                log::debug!("\x1b[0;31mBytestream Read Chunk Resp\x1b[0m: {:?}", response);
+                                info!("\x1b[0;31mBytestream Read Chunk Resp\x1b[0m: {:?}", response);
                                 return Some((Ok(response), Some(state)))
                             }
                             Err(mut e) => {
@@ -310,7 +311,7 @@ impl ByteStreamServer {
                                     // message as it will be the most relevant.
                                     e.messages.resize_with(1, || "".to_string());
                                 }
-                                log::debug!("\x1b[0;31mBytestream Read Chunk Resp\x1b[0m: Error {:?}", e);
+                                info!("\x1b[0;31mBytestream Read Chunk Resp\x1b[0m: Error {:?}", e);
                                 return Some((Err(e.into()), None))
                             }
                         }
@@ -486,7 +487,7 @@ impl ByteStreamServer {
 impl ByteStream for ByteStreamServer {
     type ReadStream = ReadStream;
     async fn read(&self, grpc_request: Request<ReadRequest>) -> Result<Response<Self::ReadStream>, Status> {
-        log::info!("\x1b[0;31mRead Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mRead Req\x1b[0m: {:?}", grpc_request.get_ref());
         let now = Instant::now();
         let resp = self
             .inner_read(grpc_request)
@@ -495,9 +496,9 @@ impl ByteStream for ByteStreamServer {
             .map_err(|e| e.into());
         let d = now.elapsed().as_secs_f32();
         if let Err(err) = resp.as_ref() {
-            log::error!("\x1b[0;31mRead Resp\x1b[0m: {} {:?}", d, err);
+            error!("\x1b[0;31mRead Resp\x1b[0m: {} {:?}", d, err);
         } else {
-            log::info!("\x1b[0;31mRead Resp\x1b[0m: {}", d);
+            info!("\x1b[0;31mRead Resp\x1b[0m: {}", d);
         }
         resp
     }
@@ -508,13 +509,13 @@ impl ByteStream for ByteStreamServer {
             .await
             .err_tip(|| "Could not unwrap first stream message")
             .map_err(Into::<Status>::into)?;
-        let hash = if log::log_enabled!(log::Level::Info) {
+        let hash = if enabled!(Level::DEBUG) {
             Some(stream.hash.clone())
         } else {
             None
         };
 
-        log::info!("\x1b[0;31mWrite Req\x1b[0m: {:?}", hash);
+        info!("\x1b[0;31mWrite Req\x1b[0m: {:?}", hash);
 
         let resp = self
             .inner_write(stream)
@@ -524,9 +525,9 @@ impl ByteStream for ByteStreamServer {
 
         let d = now.elapsed().as_secs_f32();
         if let Err(err) = resp.as_ref() {
-            log::error!("\x1b[0;31mWrite Resp\x1b[0m: {} {:?} {:?}", d, hash, err);
+            error!("\x1b[0;31mWrite Resp\x1b[0m: {} {:?} {:?}", d, hash, err);
         } else {
-            log::info!("\x1b[0;31mWrite Resp\x1b[0m: {} {:?}", d, hash);
+            info!("\x1b[0;31mWrite Resp\x1b[0m: {} {:?}", d, hash);
         }
         resp
     }
@@ -546,11 +547,11 @@ impl ByteStream for ByteStreamServer {
 
         let d = now.elapsed().as_secs_f32();
         if resp.is_err() {
-            log::error!("\x1b[0;31mQuery Req\x1b[0m: {:?}", query_request);
-            log::error!("\x1b[0;31mQuery Resp\x1b[0m: {} {:?}", d, resp);
+            error!("\x1b[0;31mQuery Req\x1b[0m: {:?}", query_request);
+            error!("\x1b[0;31mQuery Resp\x1b[0m: {} {:?}", d, resp);
         } else {
-            log::info!("\x1b[0;31mQuery Req\x1b[0m: {:?}", query_request);
-            log::info!("\x1b[0;31mQuery Resp\x1b[0m: {} {:?}", d, resp);
+            info!("\x1b[0;31mQuery Req\x1b[0m: {:?}", query_request);
+            info!("\x1b[0;31mQuery Resp\x1b[0m: {} {:?}", d, resp);
         }
         resp
     }

--- a/native-link-service/src/cas_server.rs
+++ b/native-link-service/src/cas_server.rs
@@ -25,7 +25,7 @@ use futures::TryStreamExt;
 use native_link_config::cas_server::{CasStoreConfig, InstanceName};
 use native_link_store::grpc_store::GrpcStore;
 use native_link_store::store_manager::StoreManager;
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::store_trait::Store;
 use proto::build::bazel::remote::execution::v2::content_addressable_storage_server::{
     ContentAddressableStorage, ContentAddressableStorageServer as Server,
@@ -37,6 +37,7 @@ use proto::build::bazel::remote::execution::v2::{
 };
 use proto::google::rpc::Status as GrpcStatus;
 use tonic::{Request, Response, Status};
+use tracing::{error, info};
 
 pub struct CasServer {
     stores: HashMap<String, Arc<dyn Store>>,
@@ -237,7 +238,7 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<FindMissingBlobsRequest>,
     ) -> Result<Response<FindMissingBlobsResponse>, Status> {
-        log::info!("\x1b[0;31mfind_missing_blobs Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mfind_missing_blobs Req\x1b[0m: {:?}", grpc_request.get_ref());
         let now = Instant::now();
         let resp = self
             .inner_find_missing_blobs(grpc_request)
@@ -246,9 +247,9 @@ impl ContentAddressableStorage for CasServer {
             .map_err(|e| e.into());
         let d = now.elapsed().as_secs_f32();
         if resp.is_err() {
-            log::error!("\x1b[0;31mfind_missing_blobs Resp\x1b[0m: {} {:?}", d, resp);
+            error!("\x1b[0;31mfind_missing_blobs Resp\x1b[0m: {} {:?}", d, resp);
         } else {
-            log::info!("\x1b[0;31mfind_missing_blobs Resp\x1b[0m: {} {:?}", d, resp);
+            info!("\x1b[0;31mfind_missing_blobs Resp\x1b[0m: {} {:?}", d, resp);
         }
         resp
     }
@@ -257,7 +258,7 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<BatchUpdateBlobsRequest>,
     ) -> Result<Response<BatchUpdateBlobsResponse>, Status> {
-        log::info!("\x1b[0;31mbatch_update_blobs Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mbatch_update_blobs Req\x1b[0m: {:?}", grpc_request.get_ref());
         let now = Instant::now();
         let resp = self
             .inner_batch_update_blobs(grpc_request)
@@ -266,9 +267,9 @@ impl ContentAddressableStorage for CasServer {
             .map_err(|e| e.into());
         let d = now.elapsed().as_secs_f32();
         if resp.is_err() {
-            log::error!("\x1b[0;31mbatch_update_blobs Resp\x1b[0m: {} {:?}", d, resp);
+            error!("\x1b[0;31mbatch_update_blobs Resp\x1b[0m: {} {:?}", d, resp);
         } else {
-            log::info!("\x1b[0;31mbatch_update_blobs Resp\x1b[0m: {} {:?}", d, resp);
+            info!("\x1b[0;31mbatch_update_blobs Resp\x1b[0m: {} {:?}", d, resp);
         }
         resp
     }
@@ -277,7 +278,7 @@ impl ContentAddressableStorage for CasServer {
         &self,
         grpc_request: Request<BatchReadBlobsRequest>,
     ) -> Result<Response<BatchReadBlobsResponse>, Status> {
-        log::info!("\x1b[0;31mbatch_read_blobs Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mbatch_read_blobs Req\x1b[0m: {:?}", grpc_request.get_ref());
         let now = Instant::now();
         let resp = self
             .inner_batch_read_blobs(grpc_request)
@@ -286,16 +287,16 @@ impl ContentAddressableStorage for CasServer {
             .map_err(|e| e.into());
         let d = now.elapsed().as_secs_f32();
         if resp.is_err() {
-            log::error!("\x1b[0;31mbatch_read_blobs Resp\x1b[0m: {} {:?}", d, resp);
+            error!("\x1b[0;31mbatch_read_blobs Resp\x1b[0m: {} {:?}", d, resp);
         } else {
-            log::info!("\x1b[0;31mbatch_read_blobs Resp\x1b[0m: {} {:?}", d, resp);
+            info!("\x1b[0;31mbatch_read_blobs Resp\x1b[0m: {} {:?}", d, resp);
         }
         resp
     }
 
     type GetTreeStream = GetTreeStream;
     async fn get_tree(&self, grpc_request: Request<GetTreeRequest>) -> Result<Response<Self::GetTreeStream>, Status> {
-        log::info!("\x1b[0;31mget_tree Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mget_tree Req\x1b[0m: {:?}", grpc_request.get_ref());
         let now = Instant::now();
         let resp: Result<Response<Self::GetTreeStream>, Status> = self
             .inner_get_tree(grpc_request)
@@ -304,8 +305,8 @@ impl ContentAddressableStorage for CasServer {
             .map_err(|e| e.into());
         let d = now.elapsed().as_secs_f32();
         match &resp {
-            Err(err) => log::error!("\x1b[0;31mget_tree Resp\x1b[0m: {} : {:?}", d, err),
-            Ok(_) => log::info!("\x1b[0;31mget_tree Resp\x1b[0m: {}", d),
+            Err(err) => error!("\x1b[0;31mget_tree Resp\x1b[0m: {} : {:?}", d, err),
+            Ok(_) => info!("\x1b[0;31mget_tree Resp\x1b[0m: {}", d),
         }
         resp
     }

--- a/native-link-service/src/worker_api_server.rs
+++ b/native-link-service/src/worker_api_server.rs
@@ -24,7 +24,7 @@ use native_link_config::cas_server::WorkerApiConfig;
 use native_link_scheduler::worker::{Worker, WorkerId};
 use native_link_scheduler::worker_scheduler::WorkerScheduler;
 use native_link_util::action_messages::ActionInfoHashKey;
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::platform_properties::PlatformProperties;
 use proto::com::github::trace_machina::native_link::remote_execution::worker_api_server::{
     WorkerApi, WorkerApiServer as Server,
@@ -35,6 +35,7 @@ use proto::com::github::trace_machina::native_link::remote_execution::{
 use tokio::sync::mpsc;
 use tokio::time::interval;
 use tonic::{Request, Response, Status};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 pub type ConnectWorkerStream = Pin<Box<dyn Stream<Item = Result<UpdateForWorker, Status>> + Send + Sync + 'static>>;
@@ -66,7 +67,7 @@ impl WorkerApiServer {
                     match weak_scheduler.upgrade() {
                         Some(scheduler) => {
                             if let Err(e) = scheduler.remove_timedout_workers(timestamp.as_secs()).await {
-                                log::error!("Error while running remove_timedout_workers : {:?}", e);
+                                error!("Error while running remove_timedout_workers : {:?}", e);
                             }
                         }
                         // If we fail to upgrade, our service is probably destroyed, so return.
@@ -150,7 +151,7 @@ impl WorkerApiServer {
                 if let Some(update_for_worker) = rx.recv().await {
                     return Some((Ok(update_for_worker), (rx, worker_id)));
                 }
-                log::warn!(
+                warn!(
                     "UpdateForWorker channel was closed, thus closing connection to worker node : {}",
                     worker_id
                 );
@@ -218,56 +219,56 @@ impl WorkerApi for WorkerApiServer {
         grpc_request: Request<SupportedProperties>,
     ) -> Result<Response<Self::ConnectWorkerStream>, Status> {
         let now = Instant::now();
-        log::info!("\x1b[0;31mconnect_worker Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mconnect_worker Req\x1b[0m: {:?}", grpc_request.get_ref());
         let supported_properties = grpc_request.into_inner();
         let resp = self.inner_connect_worker(supported_properties).await;
         let d = now.elapsed().as_secs_f32();
         if let Err(err) = resp.as_ref() {
-            log::error!("\x1b[0;31mconnect_worker Resp\x1b[0m: {} {:?}", d, err);
+            error!("\x1b[0;31mconnect_worker Resp\x1b[0m: {} {:?}", d, err);
         } else {
-            log::info!("\x1b[0;31mconnect_worker Resp\x1b[0m: {}", d);
+            info!("\x1b[0;31mconnect_worker Resp\x1b[0m: {}", d);
         }
         return resp.map_err(|e| e.into());
     }
 
     async fn keep_alive(&self, grpc_request: Request<KeepAliveRequest>) -> Result<Response<()>, Status> {
         let now = Instant::now();
-        log::info!("\x1b[0;31mkeep_alive Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mkeep_alive Req\x1b[0m: {:?}", grpc_request.get_ref());
         let keep_alive_request = grpc_request.into_inner();
         let resp = self.inner_keep_alive(keep_alive_request).await;
         let d = now.elapsed().as_secs_f32();
         if let Err(err) = resp.as_ref() {
-            log::error!("\x1b[0;31mkeep_alive Resp\x1b[0m: {} {:?}", d, err);
+            error!("\x1b[0;31mkeep_alive Resp\x1b[0m: {} {:?}", d, err);
         } else {
-            log::info!("\x1b[0;31mkeep_alive Resp\x1b[0m: {}", d);
+            info!("\x1b[0;31mkeep_alive Resp\x1b[0m: {}", d);
         }
         return resp.map_err(|e| e.into());
     }
 
     async fn going_away(&self, grpc_request: Request<GoingAwayRequest>) -> Result<Response<()>, Status> {
         let now = Instant::now();
-        log::info!("\x1b[0;31mgoing_away Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mgoing_away Req\x1b[0m: {:?}", grpc_request.get_ref());
         let going_away_request = grpc_request.into_inner();
         let resp = self.inner_going_away(going_away_request).await;
         let d = now.elapsed().as_secs_f32();
         if let Err(err) = resp.as_ref() {
-            log::error!("\x1b[0;31mgoing_away Resp\x1b[0m: {} {:?}", d, err);
+            error!("\x1b[0;31mgoing_away Resp\x1b[0m: {} {:?}", d, err);
         } else {
-            log::info!("\x1b[0;31mgoing_away Resp\x1b[0m: {}", d);
+            info!("\x1b[0;31mgoing_away Resp\x1b[0m: {}", d);
         }
         return resp.map_err(|e| e.into());
     }
 
     async fn execution_response(&self, grpc_request: Request<ExecuteResult>) -> Result<Response<()>, Status> {
         let now = Instant::now();
-        log::info!("\x1b[0;31mexecution_response Req\x1b[0m: {:?}", grpc_request.get_ref());
+        info!("\x1b[0;31mexecution_response Req\x1b[0m: {:?}", grpc_request.get_ref());
         let execute_result = grpc_request.into_inner();
         let resp = self.inner_execution_response(execute_result).await;
         let d = now.elapsed().as_secs_f32();
         if let Err(err) = resp.as_ref() {
-            log::error!("\x1b[0;31mexecution_response Resp\x1b[0m: {} {:?}", d, err);
+            error!("\x1b[0;31mexecution_response Resp\x1b[0m: {} {:?}", d, err);
         } else {
-            log::info!("\x1b[0;31mexecution_response Resp\x1b[0m: {}", d);
+            info!("\x1b[0;31mexecution_response Resp\x1b[0m: {}", d);
         }
         return resp.map_err(|e| e.into());
     }

--- a/native-link-store/BUILD.bazel
+++ b/native-link-store/BUILD.bazel
@@ -60,6 +60,7 @@ rust_library(
         "@crate_index//:tokio-stream",
         "@crate_index//:tokio-util",
         "@crate_index//:tonic",
+        "@crate_index//:tracing",
         "@crate_index//:uuid",
     ],
 )

--- a/native-link-store/Cargo.toml
+++ b/native-link-store/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1.29.1" }
 tokio-stream = { version = "0.1.14", features = ["fs"] }
 tokio-util = { version = "0.7.8" }
 tonic = { version = "0.9.2", features = ["gzip"] }
+tracing = "0.1.40"
 uuid = { version = "1.4.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/native-link-store/src/dedup_store.rs
+++ b/native-link-store/src/dedup_store.rs
@@ -22,11 +22,12 @@ use bincode::{self, DefaultOptions, Options};
 use error::{make_err, Code, Error, ResultExt};
 use futures::stream::{self, FuturesOrdered, StreamExt, TryStreamExt};
 use native_link_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf, StreamReader};
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::fastcdc::FastCDC;
 use native_link_util::store_trait::{Store, UploadSizeInfo};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::FramedRead;
+use tracing::warn;
 
 // NOTE: If these change update the comments in `stores.rs` to reflect
 // the new defaults.
@@ -112,7 +113,7 @@ impl DedupStore {
 
             match self.bincode_options.deserialize::<DedupIndex>(&data) {
                 Err(e) => {
-                    log::warn!(
+                    warn!(
                         "Failed to deserialize index in dedup store : {} - {:?}",
                         digest.hash_str(),
                         e

--- a/native-link-store/src/filesystem_store.rs
+++ b/native-link-store/src/filesystem_store.rs
@@ -27,7 +27,7 @@ use filetime::{set_file_atime, FileTime};
 use futures::stream::{StreamExt, TryStreamExt};
 use futures::{Future, TryFutureExt};
 use native_link_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
-use native_link_util::common::{fs, log, DigestInfo};
+use native_link_util::common::{fs, DigestInfo};
 use native_link_util::evicting_map::{EvictingMap, LenEntry};
 use native_link_util::metrics_utils::{Collector, CollectorState, MetricsComponent, Registry};
 use native_link_util::store_trait::{Store, UploadSizeInfo};
@@ -35,6 +35,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 use tokio::task::spawn_blocking;
 use tokio::time::timeout;
 use tokio_stream::wrappers::ReadDirStream;
+use tracing::{error, info, warn};
 
 // Default size to allocate memory of the buffer when reading files.
 const DEFAULT_BUFF_SIZE: usize = 32 * 1024;
@@ -96,12 +97,12 @@ impl Drop for EncodedFilePath {
         let shared_context = self.shared_context.clone();
         shared_context.active_drop_spawns.fetch_add(1, Ordering::Relaxed);
         tokio::spawn(async move {
-            log::info!("\x1b[0;31mFilesystem Store\x1b[0m: Deleting: {:?}", file_path);
+            info!("\x1b[0;31mFilesystem Store\x1b[0m: Deleting: {:?}", file_path);
             let result = fs::remove_file(&file_path)
                 .await
                 .err_tip(|| format!("Failed to remove file {:?}", file_path));
             if let Err(err) = result {
-                log::info!("\x1b[0;31mFilesystem Store\x1b[0m: {:?}", err);
+                error!("\x1b[0;31mFilesystem Store\x1b[0m: {:?}", err);
             }
             shared_context.active_drop_spawns.fetch_sub(1, Ordering::Relaxed);
         });
@@ -181,7 +182,7 @@ impl FileEntry for FileEntryImpl {
                 if let Err(remove_err) = remove_result {
                     err = err.merge(remove_err);
                 }
-                log::warn!("\x1b[0;31mFilesystem Store\x1b[0m: {:?}", err);
+                warn!("\x1b[0;31mFilesystem Store\x1b[0m: {:?}", err);
                 Err(err).err_tip(|| format!("Failed to create {:?} in filesystem store", temp_full_path))
             })
             .await?;
@@ -281,7 +282,7 @@ impl LenEntry for FileEntryImpl {
             })
             .await;
         if let Err(e) = result {
-            log::error!("{}", e);
+            error!("{}", e);
         }
     }
 
@@ -304,18 +305,16 @@ impl LenEntry for FileEntryImpl {
 
             let to_path = to_full_path_from_digest(&encoded_file_path.shared_context.temp_path, &new_digest);
 
-            log::info!(
+            info!(
                 "\x1b[0;31mFilesystem Store\x1b[0m: Unref {}, moving file {:?} to {:?}",
                 encoded_file_path.digest.hash_str(),
                 from_path,
                 to_path
             );
             if let Err(err) = fs::rename(&from_path, &to_path).await {
-                log::warn!(
+                warn!(
                     "Failed to rename file from {:?} to {:?} : {:?}",
-                    from_path,
-                    to_path,
-                    err
+                    from_path, to_path, err
                 );
             } else {
                 encoded_file_path.path_type = PathType::Temp;
@@ -407,10 +406,9 @@ async fn add_files_to_cache<Fe: FileEntry>(
     for (file_name, atime, file_size) in file_infos {
         let result = process_entry(evicting_map, &file_name, atime, file_size, anchor_time, shared_context).await;
         if let Err(err) = result {
-            log::warn!(
+            warn!(
                 "Could not add file to eviction cache, so deleting: {} - {:?}",
-                file_name,
-                err
+                file_name, err
             );
             // Ignore result.
             let _ = fs::remove_file(format!("{}/{}", &shared_context.content_path, &file_name)).await;
@@ -429,7 +427,7 @@ async fn prune_temp_path(temp_path: &str) -> Result<(), Error> {
     while let Some(dir_entry) = read_dir_stream.next().await {
         let path = dir_entry?.path();
         if let Err(err) = fs::remove_file(&path).await {
-            log::warn!("Failed to delete file in filesystem store {:?} : {:?}", &path, err);
+            warn!("Failed to delete file in filesystem store {:?} : {:?}", &path, err);
         }
     }
     Ok(())
@@ -571,7 +569,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             // Remember: At this point it is possible for another thread to have a reference to
             // `entry`, so we can't delete the file, only drop() should ever delete files.
             if let Err(err) = result {
-                log::warn!("{}", err);
+                warn!("{}", err);
                 // Warning: To prevent deadlock we need to release our lock or during `remove_if()`
                 // it will call `unref()`, which triggers a write-lock on `encoded_file_path`.
                 drop(encoded_file_path);

--- a/native-link-store/src/ref_store.rs
+++ b/native-link-store/src/ref_store.rs
@@ -19,8 +19,9 @@ use std::sync::{Arc, Mutex, Weak};
 use async_trait::async_trait;
 use error::{make_err, make_input_err, Code, Error, ResultExt};
 use native_link_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::store_trait::{Store, UploadSizeInfo};
+use tracing::error;
 
 use crate::store_manager::StoreManager;
 
@@ -126,7 +127,7 @@ impl Store for RefStore {
         match self.get_store() {
             Ok(store) => store.clone().inner_store(digest),
             Err(e) => {
-                log::error!("Failed to get store for digest: {e:?}");
+                error!("Failed to get store for digest: {e:?}");
                 self
             }
         }

--- a/native-link-store/src/s3_store.rs
+++ b/native-link-store/src/s3_store.rs
@@ -38,7 +38,7 @@ use hyper::service::Service;
 use hyper::Uri;
 use hyper_rustls::{HttpsConnector, MaybeHttpsStream};
 use native_link_util::buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
-use native_link_util::common::{log, DigestInfo};
+use native_link_util::common::DigestInfo;
 use native_link_util::retry::{ExponentialBackoff, Retrier, RetryResult};
 use native_link_util::store_trait::{Store, UploadSizeInfo};
 use rand::rngs::OsRng;
@@ -47,6 +47,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tokio_stream::wrappers::ReceiverStream;
+use tracing::info;
 
 // S3 parts cannot be smaller than this number. See:
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
@@ -418,7 +419,7 @@ impl Store for S3Store {
                 .send()
                 .await;
             if let Err(err) = abort_result {
-                log::info!("\x1b[0;31ms3_store\x1b[0m: Failed to abort_multipart_upload: {:?}", err);
+                info!("\x1b[0;31ms3_store\x1b[0m: Failed to abort_multipart_upload: {:?}", err);
             }
         }
         complete_result

--- a/native-link-util/BUILD.bazel
+++ b/native-link-util/BUILD.bazel
@@ -51,6 +51,7 @@ rust_library(
         "@crate_index//:sha2",
         "@crate_index//:tokio",
         "@crate_index//:tokio-util",
+        "@crate_index//:tracing",
     ],
 )
 

--- a/native-link-util/Cargo.toml
+++ b/native-link-util/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.167", features = ["derive"] }
 sha2 = "0.10.7"
 tokio = { version = "1.29.1", features = [ "sync", "fs", "rt", "time", "io-util" ] }
 tokio-util = { version = "0.7.8" }
+tracing = "0.1.40"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/native-link-util/src/common.rs
+++ b/native-link-util/src/common.rs
@@ -24,7 +24,6 @@ use std::task::{Context, Poll};
 use bytes::{BufMut, Bytes, BytesMut};
 use error::{make_input_err, Error, ResultExt};
 use hex::FromHex;
-pub use log;
 use prost::Message;
 use proto::build::bazel::remote::execution::v2::Digest;
 use serde::{Deserialize, Serialize};

--- a/native-link-util/src/evicting_map.rs
+++ b/native-link-util/src/evicting_map.rs
@@ -24,8 +24,9 @@ use futures::{future, StreamExt};
 use lru::LruCache;
 use native_link_config::stores::EvictionPolicy;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
-use crate::common::{log, DigestInfo};
+use crate::common::DigestInfo;
 use crate::metrics_utils::{CollectorState, Counter, CounterWithTime, MetricsComponent};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -230,7 +231,7 @@ where
             state.evicted_bytes.add(eviction_item.data.len() as u64);
             // Note: See comment in `unref()` requring global lock of insert/remove.
             eviction_item.data.unref().await;
-            log::info!("\x1b[0;31mEvicting Map\x1b[0m: Evicting {}", key.hash_str());
+            info!("\x1b[0;31mEvicting Map\x1b[0m: Evicting {}", key.hash_str());
 
             peek_entry = if let Some((_, entry)) = state.lru.peek_lru() {
                 entry

--- a/native-link-util/src/fs.rs
+++ b/native-link-util/src/fs.rs
@@ -33,6 +33,7 @@ pub use tokio::fs::DirEntry;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, ReadBuf, SeekFrom, Take};
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::time::timeout;
+use tracing::error;
 
 type StreamPosition = u64;
 type BytesRemaining = u64;
@@ -243,7 +244,7 @@ pub static OPEN_FILE_SEMAPHORE: Semaphore = Semaphore::const_new(DEFAULT_OPEN_FI
 pub fn set_open_file_limit(limit: usize) {
     let current_total = TOTAL_FILE_SEMAPHORES.load(Ordering::Acquire);
     if limit < current_total {
-        log::error!("set_open_file_limit({}) must be greater than {}", limit, current_total);
+        error!("set_open_file_limit({}) must be greater than {}", limit, current_total);
         return;
     }
     TOTAL_FILE_SEMAPHORES.fetch_add(limit - current_total, Ordering::Release);

--- a/native-link-worker/BUILD.bazel
+++ b/native-link-worker/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
         "@crate_index//:tokio",
         "@crate_index//:tokio-stream",
         "@crate_index//:tonic",
+        "@crate_index//:tracing",
         "@crate_index//:uuid",
     ],
 )
@@ -57,7 +58,6 @@ rust_test_suite(
     ],
     proc_macro_deps = [
         "@crate_index//:async-trait",
-        "@crate_index//:ctor",
     ],
     deps = [
         ":native-link-worker",
@@ -68,7 +68,6 @@ rust_test_suite(
         "//native-link-util",
         "//proto",
         "@crate_index//:async-lock",
-        "@crate_index//:env_logger",
         "@crate_index//:futures",
         "@crate_index//:hyper",
         "@crate_index//:once_cell",

--- a/native-link-worker/Cargo.toml
+++ b/native-link-worker/Cargo.toml
@@ -31,11 +31,10 @@ shlex = "1.1.0"
 tokio = { version = "1.29.1", features = ["sync", "rt", "process"] }
 tokio-stream = { version = "0.1.14", features = ["fs"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
+tracing = "0.1.40"
 uuid = { version = "1.4.0", features = ["v4"] }
 
 [dev-dependencies]
-ctor = "0.2.3"
-env_logger = "0.10.0"
 hyper = "0.14.27"
 once_cell = "1.18.0"
 pretty_assertions = "1.4.0"

--- a/native-link-worker/src/worker_utils.rs
+++ b/native-link-worker/src/worker_utils.rs
@@ -21,10 +21,10 @@ use std::str::from_utf8;
 use error::{make_err, make_input_err, Error, ResultExt};
 use futures::future::try_join_all;
 use native_link_config::cas_server::WorkerProperty;
-use native_link_util::common::log;
 use proto::build::bazel::remote::execution::v2::platform::Property;
 use proto::com::github::trace_machina::native_link::remote_execution::SupportedProperties;
 use tokio::process;
+use tracing::info;
 
 pub async fn make_supported_properties<S: BuildHasher>(
     worker_properties: &HashMap<String, WorkerProperty, S>,
@@ -60,7 +60,7 @@ pub async fn make_supported_properties<S: BuildHasher>(
                     process.args(args);
                     process.stdin(Stdio::null());
                     let err_fn = || format!("Error executing property_name {property_name} command");
-                    log::info!("Spawning process for cmd: '{}' for property: '{}'", cmd, property_name);
+                    info!("Spawning process for cmd: '{}' for property: '{}'", cmd, property_name);
                     let process_output = process.output().await.err_tip(err_fn)?;
                     if !process_output.status.success() {
                         return Err(make_err!(process_output.status.code().unwrap().into(), "{}", err_fn()));

--- a/native-link-worker/tests/local_worker_test.rs
+++ b/native-link-worker/tests/local_worker_test.rs
@@ -70,13 +70,6 @@ mod local_worker_tests {
 
     use super::*; // Must be declared in every module.
 
-    #[ctor::ctor]
-    fn init() {
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
-            .format_timestamp_millis()
-            .init();
-    }
-
     #[tokio::test]
     async fn platform_properties_smoke_test() -> Result<(), Error> {
         let mut platform_properties = HashMap::new();

--- a/src/bin/cas.rs
+++ b/src/bin/cas.rs
@@ -38,7 +38,6 @@ use native_link_service::worker_api_server::WorkerApiServer;
 use native_link_store::default_store_factory::store_factory;
 use native_link_store::store_manager::StoreManager;
 use native_link_util::common::fs::{set_idle_file_descriptor_timeout, set_open_file_limit};
-use native_link_util::common::log;
 use native_link_util::digest_hasher::{set_default_digest_hasher_func, DigestHasherFunc};
 use native_link_util::metrics_utils::{
     set_metrics_enabled_for_this_thread, Collector, CollectorState, Counter, MetricsComponent, Registry,
@@ -54,6 +53,8 @@ use tokio_rustls::TlsAcceptor;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::Server as TonicServer;
 use tower::util::ServiceExt;
+use tracing::{error, warn};
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 
 /// Note: This must be kept in sync with the documentation in `PrometheusConfig::path`.
 const DEFAULT_PROMETHEUS_METRICS_PATH: &str = "/metrics";
@@ -467,14 +468,14 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
             http.http2_max_header_list_size(value);
         }
 
-        log::warn!("Ready, listening on {}", socket_addr);
+        warn!("Ready, listening on {}", socket_addr);
         root_futures.push(Box::pin(async move {
             loop {
                 // Wait for client to connect.
                 let (tcp_stream, remote_addr) = match tcp_listener.accept().await {
                     Ok(result) => result,
                     Err(e) => {
-                        log::error!(
+                        error!(
                             "{:?}",
                             Result::<(), _>::Err(e).err_tip(|| "Failed to accept tcp connection")
                         );
@@ -494,7 +495,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                     let tls_stream = match tls_acceptor.accept(tcp_stream).await {
                         Ok(result) => result,
                         Err(e) => {
-                            log::error!(
+                            error!(
                                 "{:?}",
                                 Result::<(), _>::Err(e).err_tip(|| "Failed to accept tls stream")
                             );
@@ -509,7 +510,7 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
                     // Move it into our spawn, so if our spawn dies the cleanup happens.
                     let _guard = scope_guard;
                     if let Err(e) = fut.await {
-                        log::error!("Failed running service : {:?}", e);
+                        error!("Failed running service : {:?}", e);
                     }
                 });
             }
@@ -593,12 +594,6 @@ async fn inner_main(cfg: CasConfig, server_start_timestamp: u64) -> Result<(), B
 
 async fn get_config() -> Result<CasConfig, Box<dyn std::error::Error>> {
     let args = Args::parse();
-    // Note: We cannot mutate args, so we create another variable for it here.
-
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
-        .format_timestamp_millis()
-        .init();
-
     let json_contents = String::from_utf8(
         std::fs::read(&args.config_file).err_tip(|| format!("Could not open config file {}", args.config_file))?,
     )?;
@@ -606,6 +601,17 @@ async fn get_config() -> Result<CasConfig, Box<dyn std::error::Error>> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into())
+                .from_env_lossy(),
+        )
+        .init();
+
     let mut cfg = futures::executor::block_on(get_config())?;
 
     let mut metrics_enabled = {


### PR DESCRIPTION
For now just swap out the crate. An example of idiomatic usage is in `cas/grpc_service/ac_server.rs`. Future commits can build on this and extend the tracing and subscriber logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/387)
<!-- Reviewable:end -->
