### PR TITLE
Fix subtraction bug in start_turbo_cache.sh

### DIFF
--- a/deployment-examples/terraform/AWS/scripts/start_turbo_cache.sh
+++ b/deployment-examples/terraform/AWS/scripts/start_turbo_cache.sh
@@ -47,7 +47,7 @@ elif [ "$TYPE" == "cas" ]; then
     # 5% goes to the index memory cache.
     export NATIVE_LINK_CAS_INDEX_CACHE_LIMIT=$(( $TOTAL_AVAIL_MEMORY / 20 ))
     # 85% goes to the content memory cache.
-    export NATIVE_LINK_CAS_CONTENT_LIMIT=$(( $TOTAL_AVAIL_MEMORY - - $NATIVE_LINK_AC_CONTENT_LIMIT - $NATIVE_LINK_CAS_INDEX_CACHE_LIMIT ))
+    export NATIVE_LINK_CAS_CONTENT_LIMIT=$(( $TOTAL_AVAIL_MEMORY - $NATIVE_LINK_AC_CONTENT_LIMIT - $NATIVE_LINK_CAS_INDEX_CACHE_LIMIT ))
 
     /usr/local/bin/native-link /root/cas.json
 elif [ "$TYPE" == "scheduler" ]; then
@@ -56,7 +56,7 @@ elif [ "$TYPE" == "scheduler" ]; then
     # 5% goes to the index memory cache.
     export NATIVE_LINK_CAS_INDEX_CACHE_LIMIT=$(( $TOTAL_AVAIL_MEMORY / 20 ))
     # 85% goes to the content memory cache.
-    export NATIVE_LINK_CAS_CONTENT_LIMIT=$(( $TOTAL_AVAIL_MEMORY - - $NATIVE_LINK_AC_CONTENT_LIMIT - $NATIVE_LINK_CAS_INDEX_CACHE_LIMIT ))
+    export NATIVE_LINK_CAS_CONTENT_LIMIT=$(( $TOTAL_AVAIL_MEMORY - $NATIVE_LINK_AC_CONTENT_LIMIT - $NATIVE_LINK_CAS_INDEX_CACHE_LIMIT ))
 
     /usr/local/bin/native-link /root/scheduler.json
 elif [ "$TYPE" == "worker" ]; then


### PR DESCRIPTION
- Accept shellcheck SC2155 recommendations in start_turbo_cache.sh
- Remove SCHEDULER_URL as it is both unused & refers to a nonexistent key
- Accept shellcheck SC2004
- Fix double negative when computing remaining memory % in terraform deployment

# Description

I saw this while browsing through the code. There was a double negative sign.
While I was there, I accepted some shellcheck recommendations, which you can 
see in the individual commits.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It has not been tested.

## Checklist

- [ ] PR is contained in a single commit (I left it as separate commits for 
  reviewability. You are welcome to squash it at merge time.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/407)
<!-- Reviewable:end -->
