### PR TITLE
Add function to Store API to get the inner store when possible

### DIFF
--- a/native-link-scheduler/src/cache_lookup_scheduler.rs
+++ b/native-link-scheduler/src/cache_lookup_scheduler.rs
@@ -57,11 +57,11 @@ pub struct CacheLookupScheduler {
 
 async fn get_action_from_store(
     ac_store: &Arc<dyn Store>,
-    action_digest: &DigestInfo,
+    action_digest: DigestInfo,
     instance_name: String,
 ) -> Option<ProtoActionResult> {
     // If we are a GrpcStore we shortcut here, as this is a special store.
-    let any_store = ac_store.clone().as_any();
+    let any_store = ac_store.clone().inner_store(Some(action_digest)).as_any();
     let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
     if let Some(grpc_store) = maybe_grpc_store {
         let action_result_request = GetActionResultRequest {
@@ -78,7 +78,7 @@ async fn get_action_from_store(
             .map(|response| response.into_inner())
             .ok()
     } else {
-        get_and_decode_digest::<ProtoActionResult>(Pin::new(ac_store.as_ref()), action_digest)
+        get_and_decode_digest::<ProtoActionResult>(Pin::new(ac_store.as_ref()), &action_digest)
             .await
             .ok()
     }
@@ -185,7 +185,7 @@ impl ActionScheduler for CacheLookupScheduler {
             // Perform cache check.
             let action_digest = current_state.action_digest();
             let instance_name = action_info.instance_name().clone();
-            if let Some(action_result) = get_action_from_store(&ac_store, action_digest, instance_name).await {
+            if let Some(action_result) = get_action_from_store(&ac_store, *action_digest, instance_name).await {
                 if validate_outputs_exist(&cas_store, &action_result).await {
                     // Found in the cache, return the result immediately.
                     Arc::make_mut(&mut current_state).stage = ActionStage::CompletedFromCache(action_result);

--- a/native-link-service/src/ac_server.rs
+++ b/native-link-service/src/ac_server.rs
@@ -63,18 +63,19 @@ impl AcServer {
             .get(instance_name)
             .err_tip(|| format!("'instance_name' not configured for '{}'", instance_name))?;
 
+        // TODO(blaise.bruer) We should write a test for these errors.
+        let digest: DigestInfo = get_action_request
+            .action_digest
+            .clone()
+            .err_tip(|| "Action digest was not set in message")?
+            .try_into()?;
+
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().as_any();
+        let any_store = store.clone().inner_store(Some(digest)).as_any();
         let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
         if let Some(grpc_store) = maybe_grpc_store {
             return grpc_store.get_action_result(Request::new(get_action_request)).await;
         }
-
-        // TODO(blaise.bruer) We should write a test for these errors.
-        let digest: DigestInfo = get_action_request
-            .action_digest
-            .err_tip(|| "Action digest was not set in message")?
-            .try_into()?;
 
         Ok(Response::new(
             get_and_decode_digest::<ActionResult>(Pin::new(store.as_ref()), &digest).await?,
@@ -93,19 +94,20 @@ impl AcServer {
             .get(instance_name)
             .err_tip(|| format!("'instance_name' not configured for '{}'", instance_name))?;
 
+        let digest: DigestInfo = update_action_request
+            .action_digest
+            .clone()
+            .err_tip(|| "Action digest was not set in message")?
+            .try_into()?;
+
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().as_any();
+        let any_store = store.clone().inner_store(Some(digest)).as_any();
         let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
         if let Some(grpc_store) = maybe_grpc_store {
             return grpc_store
                 .update_action_result(Request::new(update_action_request))
                 .await;
         }
-
-        let digest: DigestInfo = update_action_request
-            .action_digest
-            .err_tip(|| "Action digest was not set in message")?
-            .try_into()?;
 
         let action_result = update_action_request
             .action_result

--- a/native-link-service/src/cas_server.rs
+++ b/native-link-service/src/cas_server.rs
@@ -104,7 +104,9 @@ impl CasServer {
             .clone();
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().as_any();
+        // Note: We don't know the digests here, so we try perform a very shallow
+        // check to see if it's a grpc store.
+        let any_store = store.clone().inner_store(None).as_any();
         let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
         if let Some(grpc_store) = maybe_grpc_store {
             return grpc_store.batch_update_blobs(Request::new(inner_request)).await;
@@ -157,7 +159,9 @@ impl CasServer {
             .clone();
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().as_any();
+        // Note: We don't know the digests here, so we try perform a very shallow
+        // check to see if it's a grpc store.
+        let any_store = store.clone().inner_store(None).as_any();
         let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
         if let Some(grpc_store) = maybe_grpc_store {
             return grpc_store.batch_read_blobs(Request::new(inner_request)).await;
@@ -214,12 +218,13 @@ impl CasServer {
             .clone();
 
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().as_any();
+        // Note: We don't know the digests here, so we try perform a very shallow
+        // check to see if it's a grpc store.
+        let any_store = store.clone().inner_store(None).as_any();
         let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
 
         if let Some(grpc_store) = maybe_grpc_store {
             let stream = grpc_store.get_tree(Request::new(inner_request)).await?.into_inner();
-            // let stream = grpc_store.read(Request::new(read_request)).await?.into_inner();
             return Ok(Response::new(Box::pin(stream)));
         }
         Err(make_err!(Code::Unimplemented, "get_tree is not implemented"))

--- a/native-link-store/src/compression_store.rs
+++ b/native-link-store/src/compression_store.rs
@@ -566,6 +566,10 @@ impl Store for CompressionStore {
         Ok(())
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/dedup_store.rs
+++ b/native-link-store/src/dedup_store.rs
@@ -340,6 +340,10 @@ impl Store for DedupStore {
         Ok(())
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/existence_cache_store.rs
+++ b/native-link-store/src/existence_cache_store.rs
@@ -178,6 +178,10 @@ impl Store for ExistenceCacheStore {
         result
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/fast_slow_store.rs
+++ b/native-link-store/src/fast_slow_store.rs
@@ -260,6 +260,10 @@ impl Store for FastSlowStore {
         Ok(())
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/filesystem_store.rs
+++ b/native-link-store/src/filesystem_store.rs
@@ -678,6 +678,10 @@ impl<Fe: FileEntry> Store for FilesystemStore<Fe> {
         Ok(())
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/grpc_store.rs
+++ b/native-link-store/src/grpc_store.rs
@@ -672,6 +672,10 @@ impl Store for GrpcStore {
         Ok(())
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/memory_store.rs
+++ b/native-link-store/src/memory_store.rs
@@ -130,6 +130,10 @@ impl Store for MemoryStore {
         Ok(())
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/noop_store.rs
+++ b/native-link-store/src/noop_store.rs
@@ -63,6 +63,10 @@ impl Store for NoopStore {
         Err(make_err!(Code::NotFound, "Not found in noop store"))
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/s3_store.rs
+++ b/native-link-store/src/s3_store.rs
@@ -530,6 +530,10 @@ impl Store for S3Store {
             .await
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/shard_store.rs
+++ b/native-link-store/src/shard_store.rs
@@ -169,6 +169,14 @@ impl Store for ShardStore {
         Box::new(self)
     }
 
+    fn inner_store(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        let Some(digest) = digest else {
+            return self;
+        };
+        let index = self.get_store_index(&digest);
+        self.weights_and_stores[index].1.clone().inner_store(Some(digest))
+    }
+
     fn register_metrics(self: Arc<Self>, registry: &mut Registry) {
         for (i, (_, store)) in self.weights_and_stores.iter().enumerate() {
             let store_registry = registry.sub_registry_with_prefix(format!("store_{i}"));

--- a/native-link-store/src/size_partitioning_store.rs
+++ b/native-link-store/src/size_partitioning_store.rs
@@ -114,6 +114,16 @@ impl Store for SizePartitioningStore {
             .await
     }
 
+    fn inner_store(self: Arc<Self>, digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        let Some(digest) = digest else {
+            return self;
+        };
+        if digest.size_bytes < self.size {
+            return self.lower_store.clone().inner_store(Some(digest));
+        }
+        self.upper_store.clone().inner_store(Some(digest))
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-store/src/verify_store.rs
+++ b/native-link-store/src/verify_store.rs
@@ -160,6 +160,10 @@ impl Store for VerifyStore {
         self.pin_inner().get_part_ref(digest, writer, offset, length).await
     }
 
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store> {
+        self
+    }
+
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
         Box::new(self)
     }

--- a/native-link-util/src/store_trait.rs
+++ b/native-link-util/src/store_trait.rs
@@ -168,6 +168,13 @@ pub trait Store: Sync + Send + Unpin {
             .merge(data_res.err_tip(|| "Failed to read stream to completion in get_part_unchunked"))
     }
 
+    /// Gets the underlying store for the given digest. This can be used to find out
+    /// what any underlying store is for a given digest will be and hand it to the caller.
+    /// A caller might want to use this to obtain a reference to the "real" underlying store
+    /// (if applicable) and check if it implements some special traits that allow optimizations.
+    /// Note: If the store performs complex operations on the data, it should return itself.
+    fn inner_store(self: Arc<Self>, _digest: Option<DigestInfo>) -> Arc<dyn Store>;
+
     /// Expect the returned Any to be `Arc<Self>`.
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send>;
 

--- a/native-link-worker/src/local_worker.rs
+++ b/native-link-worker/src/local_worker.rs
@@ -333,6 +333,7 @@ pub async fn new_local_worker(
     historical_store: Arc<dyn Store>,
 ) -> Result<LocalWorker<WorkerApiClientWrapper, RunningActionsManagerImpl>, Error> {
     let fast_slow_store = cas_store
+        .inner_store(None)
         .as_any()
         .downcast_ref::<Arc<FastSlowStore>>()
         .err_tip(|| "Expected store for LocalWorker's store to be a FastSlowStore")?

--- a/native-link-worker/src/running_actions_manager.rs
+++ b/native-link-worker/src/running_actions_manager.rs
@@ -1319,7 +1319,7 @@ impl UploadActionResults {
     ) -> Result<(), Error> {
         let Some(ac_store) = &self.ac_store else { return Ok(()) };
         // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = ac_store.clone().as_any();
+        let any_store = ac_store.clone().inner_store(Some(action_digest)).as_any();
         let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
         if let Some(grpc_store) = maybe_grpc_store {
             let update_action_request = UpdateActionResultRequest {
@@ -1472,6 +1472,7 @@ impl RunningActionsManagerImpl {
             .cas_store
             .fast_store()
             .clone()
+            .inner_store(None)
             .as_any()
             .downcast_ref::<Arc<FilesystemStore>>()
             .err_tip(|| "Expected FilesystemStore store for .fast_store() in RunningActionsManagerImpl")?


### PR DESCRIPTION
Adds `inner_store()` function to all stores that enables the resolution of inner stores recursively to get an underlying store. This is mostly for places that can perform optimizations when specific code paths can be optimized with specific stores.

towards: #409

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/410)
<!-- Reviewable:end -->
