### PR TITLE
Implement API to drain a specific worker

### DIFF
--- a/native-link-config/examples/basic_cas.json
+++ b/native-link-config/examples/basic_cas.json
@@ -137,7 +137,8 @@
       // are a frontend api.
       "worker_api": {
         "scheduler": "MAIN_SCHEDULER",
-      }
+      },
+      "admin": {}
     }
   }],
   "global": {

--- a/native-link-config/src/cas_server.rs
+++ b/native-link-config/src/cas_server.rs
@@ -150,6 +150,17 @@ pub struct PrometheusConfig {
     pub path: String,
 }
 
+#[derive(Deserialize, Debug, Default)]
+pub struct AdminConfig {
+    /// Path to register the admin API. If path is "/admin", and your
+    /// domain is "example.com", you can reach the endpoint with:
+    /// <http://example.com/admin>.
+    ///
+    /// Default: "/admin"
+    #[serde(default)]
+    pub path: String,
+}
+
 #[derive(Deserialize, Debug)]
 pub struct ServicesConfig {
     /// The Content Addressable Storage (CAS) backend config.
@@ -189,6 +200,10 @@ pub struct ServicesConfig {
     /// Prometheus metrics configuration. Metrics are gathered as a singleton
     /// but may be served on multiple endpoints.
     pub prometheus: Option<PrometheusConfig>,
+
+    /// This is the service for any administrative tasks.
+    /// It provides a REST API endpoint for administrative purposes.
+    pub admin: Option<AdminConfig>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/native-link-scheduler/src/worker_scheduler.rs
+++ b/native-link-scheduler/src/worker_scheduler.rs
@@ -59,6 +59,9 @@ pub trait WorkerScheduler: Sync + Send + Unpin {
     /// external source.
     async fn remove_timedout_workers(&self, now_timestamp: WorkerTimestamp) -> Result<(), Error>;
 
+    /// Sets if the worker is draining or not.
+    async fn set_drain_worker(&self, worker_id: WorkerId, is_draining: bool) -> Result<(), Error>;
+
     /// Register the metrics for the worker scheduler.
     fn register_metrics(self: Arc<Self>, _registry: &mut Registry) {}
 }


### PR DESCRIPTION
# Description

It implements an API to drain a specific worker.
It currently simply acts like pausing the worker and clearing existing running actions.

Fixes #351 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/413)
<!-- Reviewable:end -->
