### PR TITLE
Fix empty bytes error in s3 store and support AWS_ENDPOINT_URL

### DIFF
--- a/native-link-store/BUILD.bazel
+++ b/native-link-store/BUILD.bazel
@@ -97,6 +97,7 @@ rust_test_suite(
         "@crate_index//:filetime",
         "@crate_index//:futures",
         "@crate_index//:http",
+        "@crate_index//:hyper",
         "@crate_index//:memory-stats",
         "@crate_index//:once_cell",
         "@crate_index//:pretty_assertions",


### PR DESCRIPTION
Some http servers can send empty strings in the stream, but we
do not allow this in our code since this is the EOF signal.
    
Also adds ability to use custom AWS_ENDPOINT_URL env to change
destination of s3 endpoint.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/421)
<!-- Reviewable:end -->
