### PR TITLE
Handle SIGINT

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "dc0784bec054d555c4643aca5880a90c3362bc82e90cf390b74f4eb467f72b65",
+  "checksum": "5c9608af6e959d25bdae4ff438bca27d04472bf9c473c0b131727c9e96e96c50",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -7359,13 +7359,28 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
+          "common": [],
           "selects": {
             "aarch64-apple-darwin": [
-              "extra_traits"
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
             ]
           }
         },
@@ -14229,6 +14244,7 @@
             "process",
             "rt",
             "rt-multi-thread",
+            "signal",
             "signal-hook-registry",
             "socket2",
             "sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ prometheus-client = "0.21.2"
 rustls-pemfile = "1.0.3"
 scopeguard = "1.2.0"
 serde_json5 = "0.1.0"
-tokio = { version = "1.29.1", features = ["rt-multi-thread"] }
+tokio = { version = "1.29.1", features = ["rt-multi-thread", "signal"] }
 tokio-rustls = "0.24.1"
 tonic = { version = "0.9.2", features = ["gzip"] }
 tower = "0.4.13"

--- a/src/bin/cas.rs
+++ b/src/bin/cas.rs
@@ -654,5 +654,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .enable_all()
         .on_thread_start(move || set_metrics_enabled_for_this_thread(metrics_enabled))
         .build()?;
+
+    runtime.spawn(async move {
+        tokio::signal::ctrl_c().await.expect("Failed to listen to SIGINT");
+        eprintln!("User terminated process via SIGINT");
+        std::process::exit(130);
+    });
+
     runtime.block_on(inner_main(cfg, server_start_time))
 }


### PR DESCRIPTION
This allows Ctrl+c killing the cas executable in environments that don't invoke the it via a shell wrapper. This is the case in, for instance, minimal container images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/434)
<!-- Reviewable:end -->
