### PR TITLE
Fix lost file data in filesystem store (with test)

### DIFF
--- a/native-link-store/src/filesystem_store.rs
+++ b/native-link-store/src/filesystem_store.rs
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -33,7 +33,7 @@ use native_link_util::metrics_utils::{Collector, CollectorState, MetricsComponen
 use native_link_util::store_trait::{Store, UploadSizeInfo};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 use tokio::task::spawn_blocking;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout, Sleep};
 use tokio_stream::wrappers::ReadDirStream;
 
 // Default size to allocate memory of the buffer when reading files.
@@ -439,10 +439,18 @@ pub struct FilesystemStore<Fe: FileEntry = FileEntryImpl> {
     shared_context: Arc<SharedContext>,
     evicting_map: EvictingMap<Arc<Fe>, SystemTime>,
     read_buffer_size: usize,
+    sleep_fn: fn(Duration) -> Sleep,
 }
 
 impl<Fe: FileEntry> FilesystemStore<Fe> {
     pub async fn new(config: &native_link_config::stores::FilesystemStore) -> Result<Self, Error> {
+        Self::new_with_timeout(config, sleep).await
+    }
+
+    pub async fn new_with_timeout(
+        config: &native_link_config::stores::FilesystemStore,
+        sleep_fn: fn(Duration) -> Sleep,
+    ) -> Result<Self, Error> {
         let now = SystemTime::now();
 
         let empty_policy = native_link_config::stores::EvictionPolicy::default();
@@ -473,6 +481,7 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
             shared_context,
             evicting_map,
             read_buffer_size,
+            sleep_fn,
         };
         Ok(store)
     }
@@ -654,18 +663,25 @@ impl<Fe: FileEntry> Store for FilesystemStore<Fe> {
             // because it is waiting for a file descriptor to open before receiving data.
             // Using `ResumeableFileSlot` will re-open the file in the event it gets closed on the
             // next iteration.
+            let buf_content = buf.split().freeze();
             loop {
-                match timeout(fs::idle_file_descriptor_timeout(), writer.send(buf.split().freeze())).await {
-                    Ok(Ok(())) => break,
-                    Ok(Err(err)) => {
-                        return Err(err).err_tip(|| "Failed to send chunk in filesystem store get_part");
-                    }
-                    Err(_) => {
+                let sleep_fn = (self.sleep_fn)(fs::idle_file_descriptor_timeout());
+                tokio::pin!(sleep_fn);
+                tokio::select! {
+                    _ = & mut (sleep_fn) => {
                         resumeable_temp_file
                             .close_file()
                             .await
                             .err_tip(|| "Could not close file due to timeout in FileSystemStore::get_part")?;
                         continue;
+                    }
+                    res = writer.send(buf_content.clone()) => {
+                        match res {
+                            Ok(()) => break,
+                            Err(err) => {
+                                return Err(err).err_tip(|| "Failed to send chunk in filesystem store get_part");
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description

* Refactor `filesystem_store::FilesystemStore` to allow for controlling sleep function from outside of implementation. 

* Hoist `BytesMut.split()` to a position before the loop to prevent subsequent calls that result in an empty buffer. Original patch: https://github.com/TraceMachina/native-link/pull/426 / @Jirixek 

Fixes # (issue)

https://github.com/TraceMachina/native-link/pull/426

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`get_part_timeout_test` unit test against non-hoisted `BytesMut.split()` will trigger the bug, once split is moved bug is no longer present.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/439)
<!-- Reviewable:end -->
