### PR TITLE
Make container registry lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ might take a few minutes to publish the latest image.
 export LATEST=$(nix eval github:TraceMachina/native-link#image.imageTag --raw)
 
 # Verify the signature
-cosign verify ghcr.io/TraceMachina/native-link:${LATEST} \
+cosign verify ghcr.io/tracemachina/native-link:${LATEST} \
     --certificate-identity=https://github.com/TraceMachina/native-link/.github/workflows/image.yaml@refs/heads/main \
     --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```
@@ -57,7 +57,7 @@ For use in production pin the image to a specific revision:
 export PINNED_TAG=$(nix eval github:TraceMachina/native-link/<revision>#image.imageTag --raw)
 
 # Verify the signature
-cosign verify ghcr.io/TraceMachina/native-link:${PINNED_TAG} \
+cosign verify ghcr.io/tracemachina/native-link:${PINNED_TAG} \
     --certificate-identity=https://github.com/TraceMachina/native-link/.github/workflows/image.yaml@refs/heads/main \
     --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```

--- a/tools/publish-ghcr.nix
+++ b/tools/publish-ghcr.nix
@@ -16,7 +16,7 @@ pkgs.writeShellScriptBin "publish-ghcr" ''
   # didn't change.
   IMAGE_TAG=$(nix eval .#image.imageTag --raw)
 
-  TAGGED_IMAGE=''${GHCR_REGISTRY}/''${GHCR_IMAGE_NAME}:''${IMAGE_TAG}
+  TAGGED_IMAGE=''${GHCR_REGISTRY}/''${GHCR_IMAGE_NAME,,}:''${IMAGE_TAG}
 
   $(nix build .#image --print-build-logs --verbose) \
     && ./result \
@@ -35,7 +35,7 @@ pkgs.writeShellScriptBin "publish-ghcr" ''
   ${pkgs.cosign}/bin/cosign \
     sign \
     --yes \
-    ''${GHCR_REGISTRY}/''${GHCR_IMAGE_NAME}@$( \
+    ''${GHCR_REGISTRY}/''${GHCR_IMAGE_NAME,,}@$( \
       ${pkgs.skopeo}/bin/skopeo \
         inspect \
         --format "{{ .Digest }}" \


### PR DESCRIPTION
GitHub doesn't support our `TraceMachina` name for the registry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/447)
<!-- Reviewable:end -->
