### PR TITLE
Separate CI runs by build system

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -17,18 +17,21 @@ jobs:
       packages: write
       id-token: write
     steps:
+
       - name: Checkout
-        uses: >- # v3.5.3
-          actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Nix
         uses: >- # v7
           DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cache Nix derivations
         uses: >- # Custom commit, last pinned at 2023-11-17.
           DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+
       - name: Test image
         run: |
           nix run .#local-image-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,54 +8,6 @@ on:
     branches: [ main ]
 
 jobs:
-  windows-cargo-tests:
-    # The type of runner that the job will run on.
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3.5.3
-      with:
-        fetch-depth: 0
-    - name: Compile on windows
-      run: cargo build --all
-    - name: Test on windows
-      run: cargo test --all
-  cargo-tests:
-    # The type of runner that the job will run on.
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        # Which OS versions we will test on.
-        os_version: [ 20.04, 22.04 ]
-    steps:
-    - uses: actions/checkout@v3.5.3
-      with:
-        fetch-depth: 0
-
-    - uses: docker/setup-buildx-action@v2
-    - uses: docker/build-push-action@v4
-      with:
-        context: .
-        file: ./deployment-examples/docker-compose/Dockerfile
-        build-args: |
-          OS_VERSION=${{ matrix.os_version }}
-        load: true # This brings the build into `docker images` from buildx.
-        tags: trace_machina/native-link:dependencies
-        target: dependencies
-
-    - name: Create container for cargo
-      run: |
-        docker run --name=native-link-cargo trace_machina/native-link:dependencies bash -c ' \
-          DEBIAN_FRONTEND=noninteractive apt-get install -y curl libssl-dev gcc pkg-config python3 && \
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.70.0 \
-        ' && \
-        docker commit native-link-cargo trace_machina/native-link:cargo
-    - name: Compile & test with cargo
-      run: |
-        docker run --rm -w /root/native-link -v $PWD:/root/native-link trace_machina/native-link:cargo bash -c ' \
-          . /root/.cargo/env && \
-          cargo build --all && \
-          cargo test --all \
-        '
   docker-compose-compiles-native-link:
     # The type of runner that the job will run on.
     runs-on: ubuntu-22.04

--- a/.github/workflows/native-bazel.yaml
+++ b/.github/workflows/native-bazel.yaml
@@ -1,5 +1,5 @@
 ---
-name: Unit Tests
+name: Bazel Native
 
 on:
   push:
@@ -18,10 +18,13 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: >- # v4.1.1
+
+      - name: Checkout
+        uses: >- # v4.1.1
           actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - uses: >- # Custom commit at 2023-10-23
+      - name: Setup Bazelisk
+        uses: >- # Custom commit at 2023-10-23
           bazelbuild/setup-bazelisk@5bc144ec07bd24eaa9b5c3e8c9af4006b033b629
 
       - name: Determine Bazel cache mountpoint
@@ -41,19 +44,24 @@ jobs:
         uses: >- # v3.3.2
           actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
-          path: ${{ steps.bazel-cache.outputs.mountpoint }}
-          key: ${{ matrix.os }}-bazel-unit-test
+          path: |
+            ${{ steps.bazel-cache.outputs.mountpoint }}
+          key: |
+            ${{ matrix.os }}-bazel-native-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+          restore-keys: |
+            ${{ matrix.os }}-bazel-native-
 
       - name: Run Bazel tests
         run: |
           if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "macOS" ]; then
-            bazel test //...
+            bazel test //... --verbose_failures
           elif [ "$RUNNER_OS" == "Windows" ]; then
             bazel \
               --output_user_root=${{ steps.bazel-cache.outputs.mountpoint }} \
               test \
               --config=windows \
-              //...
+              //... \
+              --verbose_failures
           else
             echo "Unknown runner OS: $RUNNER_OS"
             exit 1

--- a/.github/workflows/native-cargo.yaml
+++ b/.github/workflows/native-cargo.yaml
@@ -1,0 +1,52 @@
+---
+name: Cargo Native
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  cargo-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2022]
+        toolchain: [stable, beta]
+    name: ${{ matrix.os }} / ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      - name: Checkout
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Set up Rust toolchain
+        run: >
+          rustup update ${{ matrix.toolchain }}
+          && rustup default ${{ matrix.toolchain }}
+        shell: bash
+
+      - name: Set up Cargo cache
+        uses: >- # v3.3.2
+          actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: |
+            ${{ runner.os }}-cargo-native-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-native-
+
+      - name: Build on ${{ runner.os }}
+        run: cargo build --all
+
+      - name: Test on ${{ runner.os }}
+        run: cargo test --all

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -11,47 +11,59 @@ permissions: read-all
 
 jobs:
   nix-bazel:
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    name: Bazel Dev / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
+
       - name: Checkout
-        uses: actions/checkout@v3.5.3
-        with:
-          fetch-depth: 0
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Mount Nix cache
-        uses: actions/cache@v3.3.2
-        with:
-          key: ${{ runner.os }}-nix
-          path: ~/nix
+        uses: >- #v7
+          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+
+      - name: Cache Nix derivations
+        uses: >- # Custom commit, last pinned at 2023-11-17.
+          DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+
       - name: Mount bazel cache
-        uses: actions/cache@v3
+        uses: >- # v3.3.2
+          actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: "~/.cache/bazel"
           key: ${{ runner.os }}-bazel-nix
+
       - name: Invoke Bazel build in Nix shell
         run: >
-          nix --store ~/nix develop --impure --command
-          bash -c "bazel test ..."
+          nix develop --impure --command
+          bash -c "bazel test ... --verbose_failures"
+
   nix-cargo:
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    name: Cargo Dev / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
-        with:
-          fetch-depth: 0
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Mount Nix cache
-        uses: actions/cache@v3.3.2
-        with:
-          key: ${{ runner.os }}-nix
-          path: ~/nix
+        uses: >- #v7
+          DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
+
+      - name: Cache Nix derivations
+        uses: >- # Custom commit, last pinned at 2023-11-17.
+          DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+
       - name: Invoke Cargo build in Nix shell
         run: >
-          nix --store ~/nix develop --impure --command
+          nix develop --impure --command
           bash -c "cargo test --all"


### PR DESCRIPTION
This change gives our CI a more uniform structure where we have a native Bazel build, a native Cargo build and Nix-wrapped Bazel/Cargo builds. The updated files clarify where/how to add new runner architectures or remove old ones.

Also fixes a few dependency issues with the existing build files and enables cache-sharing between nix workflows on a per-derivation basis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/native-link/451)
<!-- Reviewable:end -->
